### PR TITLE
moved copyCWDToId to a test_helpers file under test

### DIFF
--- a/include/CharBuf.h
+++ b/include/CharBuf.h
@@ -107,16 +107,4 @@ int getIndexForChar(CharBuf buf, char c, int index, int direction);
  */
 CharBuf copyBytesFromBuf(CharBuf buf, int index);
 
-/**
- * <pre>
- * This function creates a new CharBuf that contains the contents of two character strings
- * </pre>
- *
- * @param[in] prefix The character string of the key_id without current working directory prefix (schema notation)
- * @param[in] postfix The character string of the key_id without current working directory postfix (file path)
- *
- * @return CharBuf copy of key_id with current working directory
- */
-CharBuf copyCWDToId(char *prefix, char *postfix);
-
 #endif /* INCLUDE_CHARBUF_H_ */

--- a/src/util/CharBuf.c
+++ b/src/util/CharBuf.c
@@ -86,16 +86,3 @@ CharBuf copyBytesFromBuf(CharBuf buf, int index)
   memcpy(newBuf.chars, &buf.chars[index], newBuf.len);
   return (newBuf);
 }
-
-CharBuf copyCWDToId(char *prefix, char *postfix)
-{
-  CharBuf newBuf;
-  char cwd[100];
-
-  getcwd(cwd, sizeof(cwd));
-  newBuf = newCharBuf(strlen(prefix) + strlen(cwd) + strlen(postfix));
-  memcpy(newBuf.chars, prefix, strlen(prefix));
-  memcpy(&newBuf.chars[strlen(prefix)], cwd, strlen(cwd));
-  memcpy(&newBuf.chars[strlen(prefix) + strlen(cwd)], postfix, strlen(postfix));
-  return (newBuf);
-}

--- a/test/include/test_helper_functions.h
+++ b/test/include/test_helper_functions.h
@@ -1,0 +1,20 @@
+/*
+ * test_helper_functions.h
+ */
+
+#ifndef TEST_HELPER_FUNCTIONS_H_
+#define TEST_HELPER_FUNCTIONS_H_
+
+/**
+ * <pre>
+ * This function creates a new CharBuf that contains the contents of two character strings
+ * </pre>
+ *
+ * @param[in] prefix The character string of the key_id without current working directory prefix (schema notation)
+ * @param[in] postfix The character string of the key_id without current working directory postfix (file path)
+ *
+ * @return CharBuf copy of key_id with current working directory
+ */
+CharBuf copyCWDToId(char *prefix, char *postfix);
+
+#endif /* TEST_HELPER_FUNCTIONS_H_ */

--- a/test/src/util/key_table_test_suite.c
+++ b/test/src/util/key_table_test_suite.c
@@ -3,6 +3,7 @@
  */
 
 #include "key_table_test_suite.h"
+#include "test_helper_functions.h"
 
 #include <string.h>
 #include <stdio.h>

--- a/test/src/util/test_helper_functions.c
+++ b/test/src/util/test_helper_functions.c
@@ -1,0 +1,20 @@
+/*
+ * test_helper_functions.c
+ */
+
+#include "CharBuf.h"
+#include <unistd.h>
+#include <string.h>
+
+CharBuf copyCWDToId(char *prefix, char *postfix)
+{
+  CharBuf newBuf;
+  char cwd[100];
+
+  getcwd(cwd, sizeof(cwd));
+  newBuf = newCharBuf(strlen(prefix) + strlen(cwd) + strlen(postfix));
+  memcpy(newBuf.chars, prefix, strlen(prefix));
+  memcpy(&newBuf.chars[strlen(prefix)], cwd, strlen(cwd));
+  memcpy(&newBuf.chars[strlen(prefix) + strlen(cwd)], postfix, strlen(postfix));
+  return (newBuf);
+}

--- a/test/src/util/util_test_suite.c
+++ b/test/src/util/util_test_suite.c
@@ -3,6 +3,7 @@
  */
 
 #include "util_test_suite.h"
+#include "test_helper_functions.h"
 
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
copyCWDToId was only used by tests, so I moved it out of CharBuf and into a place we can add any future helper functions for unit tests.