### PR TITLE
Updated key_load() params for unit tests

### DIFF
--- a/test/src/util/util_test_suite.c
+++ b/test/src/util/util_test_suite.c
@@ -157,19 +157,19 @@ void test_key_load(void)
 
   pelz_log(LOG_DEBUG, "Start Key Load Test");
   key_values.key_id = copy_CWD_to_id("file:", "/test/key1.txt");
-  CU_ASSERT(key_load(&key_values) == 0);
+  CU_ASSERT(key_load(key_values.key_id.len, key_values.key_id.chars, &key_values.key.len, &key_values.key.chars) == 0);
   free_charbuf(&key_values.key_id);
   free_charbuf(&key_values.key);
 
   key_values.key_id = copy_CWD_to_id("file://localhost", "/test/key1.txt");
-  CU_ASSERT(key_load(&key_values) == 0);
+  CU_ASSERT(key_load(key_values.key_id.len, key_values.key_id.chars, &key_values.key.len, &key_values.key.chars) == 0);
   free_charbuf(&key_values.key_id);
   free_charbuf(&key_values.key);
 
   for (int i = 0; i < 5; i++)
   {
     key_values.key_id = copy_CWD_to_id(key_id_prefix[i], key_id_postfix[i]);
-    CU_ASSERT(key_load(&key_values) == 1);
+    CU_ASSERT(key_load(key_values.key_id.len, key_values.key_id.chars, &key_values.key.len, &key_values.key.chars) == 1);
     free_charbuf(&key_values.key_id);
   }
 }


### PR DESCRIPTION
The unit tests were failing due to key_load() function calls using parameters that did not match the current API. This pull request simply restructures the parameter list for three key_load() calls contained within the key_load() unit tests (test_key_load()) so that the unit tests again run cleanly.