### PR TITLE
Issue/compiler warnings

### DIFF
--- a/include/pelz_json_parser.h
+++ b/include/pelz_json_parser.h
@@ -43,7 +43,7 @@ int request_decoder(charbuf request, RequestType * request_type, charbuf * key_i
  * @return 0 on success, 1 on error
  *
  */
-int error_message_encoder(charbuf * message, char *err_message);
+int error_message_encoder(charbuf * message, const char *err_message);
 
 /**
  * <pre>

--- a/sgx.mk
+++ b/sgx.mk
@@ -128,8 +128,8 @@ Crypto_Library_Name := sgx_tcrypto
 
 Enclave_Include_Paths := -Iinclude -Isgx/include -I$(SGX_SDK)/include -I$(SGX_SDK)/include/tlibc -I$(SGX_SDK)/include/stlport -I$(SGX_SSL_INCLUDE_PATH) -Isgx
 
-Enclave_C_Flags := $(SGX_COMMON_CFLAGS) -nostdinc -fvisibility=hidden -fpie -fstack-protector $(Enclave_Include_Paths)
-Enclave_Cpp_Flags := $(Enclave_C_Flags) -std=c++03 -nostdinc++ --include "tsgxsslio.h" -DPELZ_SGX_TRUSTED
+Enclave_C_Flags := $(SGX_COMMON_CFLAGS) -nostdinc -fvisibility=hidden -fpie -fstack-protector $(Enclave_Include_Paths) -DPELZ_SGX_TRUSTED
+Enclave_Cpp_Flags := $(Enclave_C_Flags) -std=c++03 -nostdinc++ --include "tsgxsslio.h"
 Enclave_Link_Flags := $(SGX_COMMON_CFLAGS) -Wl,--no-undefined -nostdlib -nodefaultlibs -nostartfiles -L$(SGX_SSL_TRUSTED_LIB_PATH) -L$(SGX_LIBRARY_PATH) \
 	-Wl,--whole-archive -lsgx_tsgxssl \
 	-Wl,--no-whole-archive -lsgx_tsgxssl_crypto \
@@ -194,7 +194,7 @@ sgx/pelz_enclave_t.c: $(SGX_EDGER8R) sgx/pelz_enclave.edl
 	@echo "GEN => $@"
 
 sgx/pelz_enclave_t.o: sgx/pelz_enclave_t.c
-	@$(CC) $(Enclave_Cpp_Flags) -c $< -o $@
+	@$(CC) $(Enclave_C_Flags) -c $< -o $@
 	@echo "CC   <=  $<"
 
 sgx/key_table.o: src/util/key_table.c

--- a/src/util/pelz_io.c
+++ b/src/util/pelz_io.c
@@ -31,7 +31,7 @@ int get_file_ext(charbuf buf, int *ext)
   int period_index = 0;
   int ext_len = 0;
   int ext_type_size = 3;
-  char *ext_type[3] = { ".txt", ".pem", ".key" };
+  const char *ext_type[3] = { ".txt", ".pem", ".key" };
 
   period_index = get_index_for_char(buf, '.', (buf.len - 1), 1);
   ext_len = (buf.len - period_index);

--- a/src/util/pelz_io.c
+++ b/src/util/pelz_io.c
@@ -64,7 +64,7 @@ int key_load(size_t key_id_len, unsigned char *key_id, size_t * key_len, unsigne
 {
   URIValues key_id_data;
   int file_type = 0;
-  unsigned char tmp_key[MAX_KEY_LEN+1];
+  unsigned char tmp_key[MAX_KEY_LEN + 1];
   char *path = NULL;
   FILE *key_txt_f = 0;
   FILE *key_key_f = 0;
@@ -98,14 +98,15 @@ int key_load(size_t key_id_len, unsigned char *key_id, size_t * key_len, unsigne
         path = (char *) calloc((key_id_data.f_values.path.len + 1), sizeof(char));
         memcpy(path, &key_id_data.f_values.path.chars[0], key_id_data.f_values.path.len);
         key_txt_f = fopen(path, "r");
-        if(fgets((char *) tmp_key, (MAX_KEY_LEN + 1), key_txt_f) != (char*)tmp_key){
-	  pelz_log(LOG_ERR, "Failed to read key file %s", path);
-	  fclose(key_txt_f);
-	  free(path);
-	  return (1);
-	}
-	fclose(key_txt_f);
-	free(path);
+        if (fgets((char *) tmp_key, (MAX_KEY_LEN + 1), key_txt_f) != (char *) tmp_key)
+        {
+          pelz_log(LOG_ERR, "Failed to read key file %s", path);
+          fclose(key_txt_f);
+          free(path);
+          return (1);
+        }
+        fclose(key_txt_f);
+        free(path);
 
         *key = (unsigned char *) malloc(strlen((char *) tmp_key));
         *key_len = strlen((char *) tmp_key);

--- a/src/util/pelz_io.c
+++ b/src/util/pelz_io.c
@@ -64,7 +64,7 @@ int key_load(size_t key_id_len, unsigned char *key_id, size_t * key_len, unsigne
 {
   URIValues key_id_data;
   int file_type = 0;
-  unsigned char tmp_key[MAX_KEY_LEN];
+  unsigned char tmp_key[MAX_KEY_LEN+1];
   char *path = NULL;
   FILE *key_txt_f = 0;
   FILE *key_key_f = 0;
@@ -98,9 +98,15 @@ int key_load(size_t key_id_len, unsigned char *key_id, size_t * key_len, unsigne
         path = (char *) calloc((key_id_data.f_values.path.len + 1), sizeof(char));
         memcpy(path, &key_id_data.f_values.path.chars[0], key_id_data.f_values.path.len);
         key_txt_f = fopen(path, "r");
-        fgets((char *) tmp_key, (MAX_KEY_LEN + 1), key_txt_f);
-        fclose(key_txt_f);
-        free(path);
+        if(fgets((char *) tmp_key, (MAX_KEY_LEN + 1), key_txt_f) != (char*)tmp_key){
+	  pelz_log(LOG_ERR, "Failed to read key file %s", path);
+	  fclose(key_txt_f);
+	  free(path);
+	  return (1);
+	}
+	fclose(key_txt_f);
+	free(path);
+
         *key = (unsigned char *) malloc(strlen((char *) tmp_key));
         *key_len = strlen((char *) tmp_key);
         memcpy(*key, tmp_key, *key_len);

--- a/src/util/pelz_json_parser.c
+++ b/src/util/pelz_json_parser.c
@@ -61,7 +61,7 @@ int request_decoder(charbuf request, RequestType * request_type, charbuf * key_i
   return (0);
 }
 
-int error_message_encoder(charbuf * message, char *err_message)
+int error_message_encoder(charbuf * message, const char *err_message)
 {
   cJSON *root;
   char *tmp = NULL;

--- a/src/util/pelz_thread.c
+++ b/src/util/pelz_thread.c
@@ -18,7 +18,7 @@ void thread_process(void *arg)
   charbuf request;
   charbuf message;
   RequestResponseStatus status;
-  char *err_message;
+  const char *err_message;
 
   while (!pelz_key_socket_check(new_socket))
   {


### PR DESCRIPTION
I believe this fixes all the compiler warnings that are pelz-specific. There is also an associated kmyth pull request (https://github.com/NationalSecurityAgency/kmyth/pull/118) that's necessary to take care of some others that came from using the kmyth logger.