### PR TITLE
Removed unused code

### DIFF
--- a/include/pelz_io.h
+++ b/include/pelz_io.h
@@ -9,17 +9,6 @@
 extern "C"
 {
 #endif
-/**
- * <pre>
- * This function creates a new charbuf that contains the file extension of a file name sting in a charbuf
- * </pre>
- *
- * @param[in] buf The charbuf that contains the file name string
- * @param[out] ext The integer representation of the file extension type
- *
- * @return 0 on success, 1 on error
- */
-  int get_file_ext(charbuf buf, int *ext);
 
 #if !defined(PELZ_SGX_TRUSTED)
 /**

--- a/include/pelz_request_handler.h
+++ b/include/pelz_request_handler.h
@@ -22,40 +22,7 @@ typedef enum
 { ASCII = 0, HEX = 1 } FormatType;
 
 typedef enum
-{ TXT_F = 1, PEM_F = 2, SOCKET = 3 } LocationType;
-
-typedef enum
-{ F_SCHEME = 1, FTP = 2 } SchemeType;
-
-typedef enum
-{ TXT_EXT = 1, PEM_EXT = 2, KEY_EXT = 3 } ExtensionType;
-
-typedef enum
 { REQUEST_OK, KEK_LOAD_ERROR, KEY_OR_DATA_ERROR, ENCRYPT_ERROR, DECRYPT_ERROR, REQUEST_TYPE_ERROR } RequestResponseStatus;
-
-typedef struct FILEScheme
-{
-  charbuf auth;
-  charbuf path;
-  charbuf f_name;
-} FValues;
-
-typedef struct FTPScheme
-{
-  charbuf host;
-  charbuf port;
-  charbuf url_path;
-} FTPValues;
-
-typedef struct URIParseValues
-{
-  int type;
-  union
-  {
-    FValues f_values;
-    FTPValues ftp_values;
-  };
-} URIValues;
 
 #ifdef __cplusplus
 extern "C"

--- a/src/util/pelz_io.c
+++ b/src/util/pelz_io.c
@@ -30,40 +30,6 @@ void ocall_free(void *ptr, size_t len)
 }
 #endif
 
-int get_file_ext(charbuf buf, int *ext)
-{
-  int period_index = 0;
-  int ext_len = 0;
-  int ext_type_size = 3;
-  const char *ext_type[3] = { ".txt", ".pem", ".key" };
-
-  period_index = get_index_for_char(buf, '.', (buf.len - 1), 1);
-  ext_len = (buf.len - period_index);
-
-  // If buf.chars is null terminated we don't want to include
-  // the null terminator in the extension, since we're going
-  // to use strlen (applied to one of the ext_type entries)
-  // to specify a memcmp length, and strlen won't include
-  // the null terminator.
-  if (buf.chars[buf.len - 1] == '\0')
-  {
-    ext_len--;
-  }
-  pelz_log(LOG_DEBUG, "Finding file extension.");
-  for (int i = 0; i < ext_type_size; i++)
-  {
-    if (ext_len == strlen(ext_type[i]))
-    {
-      if (memcmp(buf.chars + period_index, ext_type[i], strlen(ext_type[i])) == 0)
-      {
-        *ext = i + 1;
-        break;
-      }
-    }
-  }
-  return (0);
-}
-
 int key_load(size_t key_id_len, unsigned char *key_id, size_t * key_len, unsigned char **key)
 {
   UriUriA key_id_data;


### PR DESCRIPTION
Removed unused code from Pelz because of the key_load function changes while implementing SGX. Code removal listed below:

* Removed get_file_ext function
* Removed enum LocationType
* Removed enum SchemeType
* Removed enum ExtensionType
* Removed struct FILEScheme
* Removed struct FTPScheme
* Removed struct URIParseValues