### PR TITLE
Improvement/clean up headers

### DIFF
--- a/include/aes_keywrap_3394nopad.h
+++ b/include/aes_keywrap_3394nopad.h
@@ -16,7 +16,6 @@ extern "C"
 {
 #endif
 
-#ifndef PELZ_SGX_UNTRUSTED
 /**
  * <pre>
  *
@@ -54,7 +53,6 @@ extern "C"
  */
   int aes_keywrap_3394nopad_decrypt(unsigned char *aes_key,
     size_t key_len, unsigned char *inData, size_t inData_len, unsigned char **outData, size_t * outData_len);
-#endif
 
 #ifdef __cplusplus
 }

--- a/include/key_table.h
+++ b/include/key_table.h
@@ -30,45 +30,6 @@ extern "C"
 {
 #endif
 
-#ifndef PELZ_SGX_UNTRUSTED
-/**
- * <pre>
- * This function initializes a key table for lookup.
- * </pre>
- *
- * @param[in] key_table The pointer for key table to be initialized
- * @param[out] key_table The initialized key table
- *
- * @return 0 on success, 1 on error
- */
-  int key_table_init(void);
-
-/**
- * <pre>
- * This function destroys the key table.
- * </pre>
- *
- * @param[in] key_table The key table to be destroyed
- *
- * @return 0 on success, 1 on error
- */
-  int key_table_destroy(void);
-
-/**
- * <pre>
- * This function to delete values in hash table based on location in key_id.
- * </pre>
- *
- * @param[in] key_id.chars Key identifier assumed to be null terminated
- * @param[in] key_id.len The length of the key identifier
- * @param[in] key_table The key table that the key needs to be deleted from
- * @param[out] key_table The key table without the deleted key
- *
- * @return 0 on success, 1 on error
- */
-  int key_table_delete(charbuf key_id);
-#endif
-
 /**
  * <pre>
  * This function to add values in hash table based on location in key_id.

--- a/include/pelz_io.h
+++ b/include/pelz_io.h
@@ -21,54 +21,6 @@ extern "C"
  */
   int get_file_ext(charbuf buf, int *ext);
 
-#if !defined(PELZ_SGX_TRUSTED)
-/**
- * <pre>
- * Load key from location stated by Key ID
- * <pre>
- *
- * @param[in] key_id_len   the length of the key identifierr
- * @param[in] key_id       a pointer to the key identifier
- * @param[out] key_len     the length of the loaded key
- * @param[out] key         a pointer to a pointer to the key, will be
- *                         allocated within key_load
- *
- * @return 0 on success, 1 on error
- */
-  int key_load(size_t key_id_len, unsigned char *key_id, size_t * key_len, unsigned char **key);
-#endif
-
-#if defined(PELZ_SGX_UNTRUSTED)
-/**
- * <pre>
- * Malloc untrusted memory from within the enclave. The result must
- * be checked to ensure it lies outside the enclave by calling
- * sgx_is_outside_enclave(*buf, size);
- * <pre>
- *
- * @param[in]     size the size to allocate (in bytes).
- * @param[in,out] buf  a pointer to a pointer to hold the allocated space
- *
- * @return none
- */
-  void ocall_malloc(size_t size, char **buf);
-
-/**
- * <pre>
- * Frees untrusted memory from within the enclave. If the length of the
- * buffer is available the caller should check that it is entirely outside
- * enclave memory by calling
- * sgx_is_outside_enclave(ptr, len);
- * <pre>
-
- * @param[in] ptr the pointer to be freed
- * @param[in] len the length of the buffer pointed to by ptr
- *
- * @return none
- */
-  void ocall_free(void *ptr, size_t len);
-#endif
-
 /**
  * <pre>
  * Using key_id to check if there is actual file

--- a/include/pelz_request_handler.h
+++ b/include/pelz_request_handler.h
@@ -57,33 +57,4 @@ typedef struct URIParseValues
   };
 } URIValues;
 
-#ifdef __cplusplus
-extern "C"
-{
-#endif
-
-#ifndef PELZ_SGX_UNTRUSTED
-/**
- * <pre>
- * This function implements the request handling by looking if Pelz already has
- * the key and if not then adding the key to the key table. Along with the
- * key lookup, this function checks the request type then based on the request
- * type it calls the wrap or unwrap functions to return requested key value.
- * <pre>
- *
- * @param[in] request_type the type of the request (encrypt or decrypt)
- * @param[in] key_id       the key_id of the key to be used for the request
- * @param[in] data         the input data
- * @param[out] output      a pointer to a charbuf to hold the output, will
- *                         be created inside the call
- *
- * @return REQUEST_OK on success, an error message indicating the type of
- *                    error otherwise.
- */
-  RequestResponseStatus pelz_request_handler(RequestType request_type, charbuf key_id, charbuf data, charbuf * output);
-#endif
-
-#ifdef __cplusplus
-}
-#endif
-#endif                          /* INCLUDE_PELZ_REQUEST_HANDLER_H_ */
+#endif /* INCLUDE_PELZ_REQUEST_HANDLER_H_ */

--- a/sgx/pelz_enclave.edl
+++ b/sgx/pelz_enclave.edl
@@ -8,16 +8,109 @@ enclave {
 	include "charbuf.h"
         include "util.h"
 	trusted {
+	/**
+ * <pre>
+ * This function initializes a key table for lookup.
+ * </pre>
+ *
+ * @param[in] key_table The pointer for key table to be initialized
+ * @param[out] key_table The initialized key table
+ *
+ * @return 0 on success, 1 on error
+ */
 	public int key_table_init(void);
+
+/**
+ * <pre>
+ * This function destroys the key table.
+ * </pre>
+ *
+ * @param[in] key_table The key table to be destroyed
+ *
+ * @return 0 on success, 1 on error
+ */
 	public int key_table_destroy(void);
+
+/**
+ * <pre>
+ * This function to delete values in hash table based on location in key_id.
+ * </pre>
+ *
+ * @param[in] key_id.chars Key identifier assumed to be null terminated
+ * @param[in] key_id.len The length of the key identifier
+ * @param[in] key_table The key table that the key needs to be deleted from
+ * @param[out] key_table The key table without the deleted key
+ *
+ * @return 0 on success, 1 on error
+ */
 	public int key_table_delete(charbuf key_id);
+
+
+/**
+ * <pre>
+ * This function implements the request handling by looking if Pelz already has
+ * the key and if not then adding the key to the key table. Along with the
+ * key lookup, this function checks the request type then based on the request
+ * type it calls the wrap or unwrap functions to return requested key value.
+ * <pre>
+ *
+ * @param[in] request_type the type of the request (encrypt or decrypt)
+ * @param[in] key_id       the key_id of the key to be used for the request
+ * @param[in] data         the input data
+ * @param[out] output      a pointer to a charbuf to hold the output, will
+ *                         be created inside the call
+ *
+ * @return REQUEST_OK on success, an error message indicating the type of
+ *                    error otherwise.
+ */
 	public RequestResponseStatus pelz_request_handler(RequestType request_type, charbuf key_id, charbuf data, [out] charbuf* output);
 	};
 	untrusted {
+	/**
+ * <pre>
+ * Load key from location stated by Key ID
+ * <pre>
+ *
+ * @param[in] key_id_len   the length of the key identifierr
+ * @param[in] key_id       a pointer to the key identifier
+ * @param[out] key_len     the length of the loaded key
+ * @param[out] key         a pointer to a pointer to the key, will be
+ *                         allocated within key_load
+ *
+ * @return 0 on success, 1 on error
+ */
 	int key_load(size_t key_id_len, [in, size=key_id_len] unsigned char* key_id,
 	             [out] size_t* key_len, [user_check] unsigned char** key);
-	void ocall_malloc(size_t size, [user_check] char** buf);
-	void ocall_free([user_check] void* ptr, size_t len);
+
+/**
+ * <pre>
+ * Malloc untrusted memory from within the enclave. The result must
+ * be checked to ensure it lies outside the enclave by calling
+ * sgx_is_outside_enclave(*buf, size);
+ * <pre>
+ *
+ * @param[in]     size the size to allocate (in bytes).
+ * @param[in,out] buf  a pointer to a pointer to hold the allocated space
+ *
+ * @return none
+ */
+void ocall_malloc(size_t size, [user_check] char** buf);
+
+
+/**
+ * <pre>
+ * Frees untrusted memory from within the enclave. If the length of the
+ * buffer is available the caller should check that it is entirely outside
+ * enclave memory by calling
+ * sgx_is_outside_enclave(ptr, len);
+ * <pre>
+
+ * @param[in] ptr the pointer to be freed
+ * @param[in] len the length of the buffer pointed to by ptr
+ *
+ * @return none
+ */
+void ocall_free([user_check] void* ptr, size_t len);
 	};
 };	
 	

--- a/sgx/pelz_enclave.edl
+++ b/sgx/pelz_enclave.edl
@@ -71,7 +71,7 @@ enclave {
  * Load key from location stated by Key ID
  * <pre>
  *
- * @param[in] key_id_len   the length of the key identifierr
+ * @param[in] key_id_len   the length of the key identifier
  * @param[in] key_id       a pointer to the key identifier
  * @param[out] key_len     the length of the loaded key
  * @param[out] key         a pointer to a pointer to the key, will be

--- a/test/include/enclave_test_suite.h
+++ b/test/include/enclave_test_suite.h
@@ -14,5 +14,4 @@ int enclave_suite_add_tests(CU_pSuite suite);
 void test_table_initDestroy(void);
 void test_table_request(void);
 void test_table_requestDelete(void);
-
 #endif /* ENCLAVE_TEST_SUITE_H_ */

--- a/test/include/util_test_suite.h
+++ b/test/include/util_test_suite.h
@@ -13,7 +13,6 @@
 int utility_suite_add_tests(CU_pSuite suite);
 
 //TESTS
-void test_key_load(void);
 void test_file_check(void);
 void test_decodeEncodeBase64Data(void);
 

--- a/test/src/util/util_test_suite.c
+++ b/test/src/util/util_test_suite.c
@@ -4,6 +4,7 @@
 
 #include "util_test_suite.h"
 #include "test_helper_functions.h"
+#include "pelz_enclave_u.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -22,10 +23,6 @@ int utility_suite_add_tests(CU_pSuite suite)
   {
     return 1;
   }
-  /* if (NULL == CU_add_test(suite, "Verify Key Load with differing inputs", test_key_load)) */
-  /* { */
-  /*   return 1; */
-  /* } */
   if (NULL == CU_add_test(suite, "Test decode and encode Base64Data", test_decodeEncodeBase64Data))
   {
     return 1;
@@ -60,20 +57,6 @@ void test_file_check(void)
   remove("testfile");
   CU_ASSERT(file_check((char *) "testfile") == 1);
 }
-
-/*
- * Tests accuracy of function file_check
- */
-/* void test_key_load(void) */
-/* { */
-/*   KeyEntry key_values; */
-
-/*   pelz_log(LOG_DEBUG, "Start Key Load Test"); */
-/*   key_values.key_id = copy_CWD_to_id("file:", "/test/key1.txt"); */
-/*   CU_ASSERT(key_load(key_values.key_id.len, key_values.key_id.chars, &key_values.key.len, &key_values.key.chars) == 0); */
-/*   free_charbuf(&key_values.key_id); */
-/*   free_charbuf(&key_values.key); */
-/* } */
 
 void test_decodeEncodeBase64Data(void)
 {

--- a/test/src/util/util_test_suite.c
+++ b/test/src/util/util_test_suite.c
@@ -22,10 +22,10 @@ int utility_suite_add_tests(CU_pSuite suite)
   {
     return 1;
   }
-  if (NULL == CU_add_test(suite, "Verify Key Load with differing inputs", test_key_load))
-  {
-    return 1;
-  }
+  /* if (NULL == CU_add_test(suite, "Verify Key Load with differing inputs", test_key_load)) */
+  /* { */
+  /*   return 1; */
+  /* } */
   if (NULL == CU_add_test(suite, "Test decode and encode Base64Data", test_decodeEncodeBase64Data))
   {
     return 1;
@@ -64,16 +64,16 @@ void test_file_check(void)
 /*
  * Tests accuracy of function file_check
  */
-void test_key_load(void)
-{
-  KeyEntry key_values;
+/* void test_key_load(void) */
+/* { */
+/*   KeyEntry key_values; */
 
-  pelz_log(LOG_DEBUG, "Start Key Load Test");
-  key_values.key_id = copy_CWD_to_id("file:", "/test/key1.txt");
-  CU_ASSERT(key_load(key_values.key_id.len, key_values.key_id.chars, &key_values.key.len, &key_values.key.chars) == 0);
-  free_charbuf(&key_values.key_id);
-  free_charbuf(&key_values.key);
-}
+/*   pelz_log(LOG_DEBUG, "Start Key Load Test"); */
+/*   key_values.key_id = copy_CWD_to_id("file:", "/test/key1.txt"); */
+/*   CU_ASSERT(key_load(key_values.key_id.len, key_values.key_id.chars, &key_values.key.len, &key_values.key.chars) == 0); */
+/*   free_charbuf(&key_values.key_id); */
+/*   free_charbuf(&key_values.key); */
+/* } */
 
 void test_decodeEncodeBase64Data(void)
 {


### PR DESCRIPTION
This merge moves all comments on ecalls and ocalls to the edl file and removes the entries from the regular headers.