### PR TITLE
Improvement/better file uri parsing

### DIFF
--- a/include/pelz_uri_helpers.h
+++ b/include/pelz_uri_helpers.h
@@ -29,12 +29,11 @@ extern "C"
 /**
  * @brief Returns the filename from a null-terminated key_id.
  *
- * @param[in] null_terminated_key_id The key id embedded in a
- *                                   null-terminated string
+ * @param[in] The (already parsed) URI.
  *
  * @return The filename, or NULL on error.
  */
-  char *get_filename_from_key_id(const char *null_terminated_key_id);
+  char *get_filename_from_key_id(UriUriA uri);
 
 /**
  * @brief Extracts the necessary parts from a parsed pelz uri.

--- a/src/util/pelz_io.c
+++ b/src/util/pelz_io.c
@@ -126,7 +126,7 @@ int key_load(size_t key_id_len, unsigned char *key_id, size_t * key_len, unsigne
   {
   case FILE_URI:
     {
-      char *filename = get_filename_from_key_id(key_uri_to_parse);
+      char *filename = get_filename_from_key_id(key_id_data);
 
       if (filename == NULL)
       {

--- a/src/util/pelz_uri_helpers.c
+++ b/src/util/pelz_uri_helpers.c
@@ -21,22 +21,30 @@ URI_SCHEME get_uri_scheme(UriUriA uri)
 
 char *get_filename_from_key_id(UriUriA uri)
 {
-  ptrdiff_t field_length = uri.pathHead->text.afterLast - uri.pathHead->text.first;
+  if (uri.pathHead == NULL)
+  {
+    pelz_log(LOG_ERR, "Invalid URI.");
+    return NULL;
+  }
+
+  ptrdiff_t field_length = uri.pathTail->text.afterLast - uri.pathHead->text.first;
 
   if (field_length <= 0)
   {
     pelz_log(LOG_ERR, "Invalid URI field length.");
     return NULL;
   }
-  char *filename = (char*)calloc(field_length + 1, sizeof(char));
+
+  // The extra 2 bytes here are to prepend '/' and to append a null byte.
+  char *filename = (char *) calloc(field_length + 2, sizeof(char));
 
   if (filename == NULL)
   {
     pelz_log(LOG_ERR, "Failed to allocate memory for filename.");
     return NULL;
   }
-  memcpy(filename, uri.pathHead->text.first, field_length);
-  printf("%s\n", filename);
+  filename[0] = '/';
+  memcpy(filename + 1, uri.pathHead->text.first, field_length);
   return filename;
 }
 

--- a/src/util/pelz_uri_helpers.c
+++ b/src/util/pelz_uri_helpers.c
@@ -19,26 +19,24 @@ URI_SCHEME get_uri_scheme(UriUriA uri)
   return URI_SCHEME_UNKNOWN;
 }
 
-char *get_filename_from_key_id(const char *null_terminated_key_id)
+char *get_filename_from_key_id(UriUriA uri)
 {
-  if (null_terminated_key_id == NULL)
+  ptrdiff_t field_length = uri.pathHead->text.afterLast - uri.pathHead->text.first;
+
+  if (field_length <= 0)
   {
+    pelz_log(LOG_ERR, "Invalid URI field length.");
     return NULL;
   }
-
-  // The magic 4 here is from the uriparser documentation.
-  char *filename = (char *) malloc(strlen((const char *) null_terminated_key_id) - 4);
+  char *filename = (char*)calloc(field_length + 1, sizeof(char));
 
   if (filename == NULL)
   {
+    pelz_log(LOG_ERR, "Failed to allocate memory for filename.");
     return NULL;
   }
-  if (uriUriStringToUnixFilenameA((const char *) null_terminated_key_id, filename))
-  {
-    pelz_log(LOG_ERR, "Failed to parse key file name from URI %s\n", null_terminated_key_id);
-    free(filename);
-    return NULL;
-  }
+  memcpy(filename, uri.pathHead->text.first, field_length);
+  printf("%s\n", filename);
   return filename;
 }
 

--- a/test/src/util/test_pelz_uri_helpers.c
+++ b/test/src/util/test_pelz_uri_helpers.c
@@ -23,12 +23,11 @@ void test_scheme_extraction(void)
   const char *file_uri = "file:/filename";
   const char *file_uri_2 = "file:///filename";
   const char *pelz_uri = "pelz://common_name/0/key_uid/other_data";
-
   UriUriA uri;
 
   uriParseSingleUriA(&uri, file_uri, NULL);
   CU_ASSERT(get_uri_scheme(uri) == FILE_URI);
-  char *filename = get_filename_from_key_id(file_uri);
+  char *filename = get_filename_from_key_id(uri);
 
   CU_ASSERT(strncmp((char *) filename, "/filename", strlen("/filename")) == 0);
   free(filename);
@@ -36,7 +35,7 @@ void test_scheme_extraction(void)
 
   uriParseSingleUriA(&uri, file_uri_2, NULL);
   CU_ASSERT(get_uri_scheme(uri) == FILE_URI);
-  filename = get_filename_from_key_id(file_uri_2);
+  filename = get_filename_from_key_id(uri);
   CU_ASSERT(strncmp((char *) filename, "/filename", strlen("/filename")) == 0);
   free(filename);
   uriFreeUriMembersA(&uri);


### PR DESCRIPTION
This replaces the use of ```uriUriStringToUnixFilenameA``` from the ```uriparser``` library with explicit filename parsing because of a suggestion by the maintainer of ```uriparser``` that this version will be easier for us to maintain.