### PR TITLE
removed indent

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -3,7 +3,7 @@
 ## Dependencies
 
 ### For Ubuntu:
-    apt install make cmake indent gcc openssl libssl-dev libffi-dev libcunit1 libcunit1-dev libcunit1-doc
+    apt install make cmake gcc openssl libssl-dev libffi-dev libcunit1 libcunit1-dev libcunit1-doc
 
 #### cJSON:
 cJSON is required to build pelz.  

--- a/Makefile
+++ b/Makefile
@@ -71,24 +71,6 @@ else
 		SGX_COMMON_CFLAGS += -O2
 endif
 
-# Specify indentation options
-INDENT_OPTS = -bli0#                     indent braces zero spaces
-INDENT_OPTS += -bap#                     blank lines after procedure bodies
-INDENT_OPTS += -bad#                     blank lines after declarations
-INDENT_OPTS += -sob#                     swallow optional blank lines
-INDENT_OPTS += -cli0#                    case label indent of zero spaces
-INDENT_OPTS += -npcs#                    no space after function in calls
-INDENT_OPTS += -nbc#                     don't force newlines after commas
-INDENT_OPTS += -bls#                     put braces on line after struct decl
-INDENT_OPTS += -blf#                     put braces on line after func def
-INDENT_OPTS += -nlp#                     align continued lines at parentheses
-INDENT_OPTS += -ip0#                     indent parameter types zero spaces
-INDENT_OPTS += -ts2#                     set tab size to two spaces
-INDENT_OPTS += -nut#                     use spaces instead of tabs
-INDENT_OPTS += -npsl#                    type of proc on same line as name
-INDENT_OPTS += -bbo#                     prefer break before boolean operator
-INDENT_OPTS += -l128#                    max non-comment line length is 128
-
 ######## App Settings ########
 
 ifneq ($(SGX_MODE), HW)
@@ -496,11 +478,6 @@ sgx/$(Signed_Enclave_Name): sgx/$(Enclave_Name) sgx/$(Enclave_Signing_Key)
 .PHONY: pre
 
 pre:
-	@indent $(INDENT_OPTS) src/*/*.c
-	@indent $(INDENT_OPTS) include/*.h
-	@indent $(INDENT_OPTS) test/src/*.c
-	@indent $(INDENT_OPTS) test/src/*/*.c
-	@indent $(INDENT_OPTS) test/include/*.h
 	@rm -f src/*/*.c~
 	@rm -f include/*.h~
 	@rm -f test/src/*.c~


### PR DESCRIPTION
Indent initially helped everyone maintain similar/identical formatting, but over time it has created more noise than it has eliminated. Removing this from the build should help developers track meaningful changes.