### PR TITLE
Fix messaging bugs

### DIFF
--- a/include/pelz_io.h
+++ b/include/pelz_io.h
@@ -107,11 +107,11 @@ extern "C"
  * Reads a complete message from the interface FIFO pipe
  * </pre>
  *
- * @param[in] pipe The FIFO pipe name
+ * @param[in] fd The FIFO pipe file descriptor number
  *
  * @return 0 if success, 1 if error
  */
-  int read_listener(char *pipe);
+  int read_listener(int fd);
 
 /**
  * <pre>
@@ -140,6 +140,17 @@ extern "C"
  * @return ParseResponseStatus status message indicating the outcome of parse
  */
   ParseResponseStatus parse_pipe_message(char **tokens, size_t num_tokens);
+
+/**
+ * <pre>
+ * Opens a FIFO pipe for reading
+ * </pre>
+ *
+ * @param[in] name The FIFO pipe name
+ *
+ * @return the pipe's file descriptor number if success, -1 if error
+ */
+int open_read_pipe(char *name);
 
 /**
  * <pre>

--- a/include/pelz_io.h
+++ b/include/pelz_io.h
@@ -104,7 +104,7 @@ extern "C"
 
 /**
  * <pre>
- * Reads a message from the interface FIFO pipe
+ * Reads a complete message from the interface FIFO pipe
  * </pre>
  *
  * @param[in] pipe The FIFO pipe name

--- a/include/pelz_io.h
+++ b/include/pelz_io.h
@@ -80,11 +80,23 @@ extern "C"
 
 /**
  * <pre>
- * Writes a message to the FIFO pipe
+ * Writes a message to an already-opened FIFO pipe
+ * </pre>
+ *
+ * @param[in] fd The FIFO pipe file descriptor
+ * @param[in] msg Message to be sent along the pipe, null-terminated
+ *
+ * @return 0 if success, 1 if error
+ */
+  int write_to_pipe_fd(int fd, char *msg);
+
+/**
+ * <pre>
+ * Writes a message to a FIFO pipe
  * </pre>
  *
  * @param[in] pipe The FIFO pipe name
- * @param[in] msg Message to be sent along the pipe
+ * @param[in] msg Message to be sent along the pipe, null-terminated
  *
  * @return 0 if success, 1 if error
  */
@@ -150,7 +162,18 @@ extern "C"
  *
  * @return the pipe's file descriptor number if success, -1 if error
  */
-int open_read_pipe(char *name);
+  int open_read_pipe(char *name);
+
+/**
+ * <pre>
+ * Opens a FIFO pipe for writing
+ * </pre>
+ *
+ * @param[in] name The FIFO pipe name
+ *
+ * @return the pipe's file descriptor number if success, -1 if error
+ */
+  int open_write_pipe(char *name);
 
 /**
  * <pre>

--- a/src/util/cmd_interface.c
+++ b/src/util/cmd_interface.c
@@ -91,7 +91,8 @@ static int msg_cmd(char *pipe, char *msg)
 
   pelz_log(LOG_DEBUG, "Message: %s", msg);
   ret = write_to_pipe((char*) PELZSERVICE, msg);
-  if (ret) {
+  if (ret)
+  {
     return ret;
   }
 

--- a/src/util/cmd_interface.c
+++ b/src/util/cmd_interface.c
@@ -77,7 +77,7 @@ CmdArgValue check_arg(char *arg)
 
 int msg_arg(char *pipe, int pipe_len, int cmd, char *arg, int arg_len)
 {
-  char *msg = (char *) calloc((8 + pipe_len + arg_len), sizeof(char));
+  char *msg = (char *) calloc((10 + pipe_len + arg_len), sizeof(char));
   sprintf(msg, "pelz %d %.*s %.*s", cmd, pipe_len, pipe, arg_len, arg);
   pelz_log(LOG_DEBUG, "Message: %s", msg);
   write_to_pipe((char*) PELZSERVICE, msg);
@@ -92,7 +92,7 @@ int msg_arg(char *pipe, int pipe_len, int cmd, char *arg, int arg_len)
 
 int msg_list(char *pipe, int pipe_len, int cmd)
 {
-  char *msg = (char *) calloc((8 + pipe_len), sizeof(char));
+  char *msg = (char *) calloc((10 + pipe_len), sizeof(char));
   sprintf(msg, "pelz %d %.*s", cmd, pipe_len, pipe);
   pelz_log(LOG_DEBUG, "Message: %s", msg);
   write_to_pipe((char*) PELZSERVICE, msg);

--- a/src/util/cmd_interface.c
+++ b/src/util/cmd_interface.c
@@ -82,12 +82,7 @@ int msg_arg(char *pipe, int pipe_len, int cmd, char *arg, int arg_len)
   pelz_log(LOG_DEBUG, "Message: %s", msg);
   write_to_pipe((char*) PELZSERVICE, msg);
   free(msg);
-  if (read_listener(pipe))
-  {
-    pelz_log(LOG_DEBUG, "Error read from pipe.");
-    return 1;
-  }
-  return 0;
+  return read_listener(pipe);
 }
 
 int msg_list(char *pipe, int pipe_len, int cmd)
@@ -97,12 +92,5 @@ int msg_list(char *pipe, int pipe_len, int cmd)
   pelz_log(LOG_DEBUG, "Message: %s", msg);
   write_to_pipe((char*) PELZSERVICE, msg);
   free(msg);
-  do
-  {
-    if (read_listener(pipe))
-    {
-      break;
-    }
-  } while (1);
-  return 0;
+  return read_listener(pipe);
 }

--- a/src/util/pelz_io.c
+++ b/src/util/pelz_io.c
@@ -342,7 +342,6 @@ int write_to_pipe_fd(int fd, char *msg)
   bytes_written = write(fd, msg, msg_len);
   if (bytes_written == msg_len)
   {
-    pelz_log(LOG_DEBUG, "Wrote: %.*s", msg_len, msg);
     return 0;
   }
   else

--- a/src/util/pelz_io.c
+++ b/src/util/pelz_io.c
@@ -413,28 +413,14 @@ int read_from_pipe(char *pipe, char **msg)
   return 0;
 }
 
-int read_listener(char *pipe)
+int read_listener(int fd)
 {
-  if (file_check(pipe))
-  {
-    pelz_log(LOG_ERR, "Pipe not found");
-    return 1;
-  }
-
   fd_set set;
   struct timeval timeout;
   int rv;
   char msg[BUFSIZE];
   int line_start, line_len, i;
   int bytes_read;
-
-  int fd = open(pipe, O_RDONLY | O_NONBLOCK);
-
-  if (fd == -1)
-  {
-    pelz_log(LOG_ERR, "Error opening pipe for reading");
-    return 1;
-  }
 
   FD_ZERO(&set);            // clear the set
   FD_SET(fd, &set);   // add file descriptor to the set
@@ -853,7 +839,18 @@ ParseResponseStatus parse_pipe_message(char **tokens, size_t num_tokens)
   return INVALID;
 }
 
-int remove_pipe (char *name)
+int open_read_pipe(char *name)
+{
+  if (file_check(name))
+  {
+    pelz_log(LOG_ERR, "Pipe not found");
+    return -1;
+  }
+
+  return open(name, O_RDONLY | O_NONBLOCK);
+}
+
+int remove_pipe(char *name)
 {
   //Exit and remove FIFO
   if (unlink(name) == 0)

--- a/src/util/pelz_thread.c
+++ b/src/util/pelz_thread.c
@@ -115,7 +115,7 @@ void *fifo_thread_process(void *arg)
           break;
         }
 
-        sprintf(resp, "%s (%d)", resp_str[ret], (int) list_num);
+        sprintf(resp, "%s (%d)\n", resp_str[ret], (int) list_num);
         if (write_to_pipe(tokens[2], resp))
         {
            pelz_log(LOG_DEBUG, "Unable to send response to pelz cmd.");
@@ -127,7 +127,6 @@ void *fifo_thread_process(void *arg)
 
         for (count = 0; count < list_num; count++)
         {
-          sleep(0.02);
           table_id(eid, &status, KEY, count, &id);
           if (status != OK)
           {
@@ -135,14 +134,13 @@ void *fifo_thread_process(void *arg)
             continue;
           }
 
-          sprintf(resp, "%.*s", (int) id.len, id.chars);
+          sprintf(resp, "%.*s\n", (int) id.len, id.chars);
           if (write_to_pipe(tokens[2], resp))
           {
             pelz_log(LOG_DEBUG, "Unable to send response to pelz cmd.");
           }
         }
-        sleep (0.02);
-        if (write_to_pipe(tokens[2], (char *) "END"))
+        if (write_to_pipe(tokens[2], (char *) "END\n"))
         {
           pelz_log(LOG_DEBUG, "Unable to send response to pelz cmd.");
         }
@@ -159,7 +157,7 @@ void *fifo_thread_process(void *arg)
           break;
         }
 
-        sprintf(resp, "%s (%d)", resp_str[ret], (int) list_num);
+        sprintf(resp, "%s (%d)\n", resp_str[ret], (int) list_num);
         if (write_to_pipe(tokens[2], resp))
         {
            pelz_log(LOG_DEBUG, "Unable to send response to pelz cmd.");
@@ -171,7 +169,6 @@ void *fifo_thread_process(void *arg)
 
         for (count = 0; count < list_num; count++)
         {
-          sleep(0.02);
           table_id(eid, &status, SERVER, count, &id);
           if (status != OK)
           {
@@ -179,14 +176,13 @@ void *fifo_thread_process(void *arg)
             continue;
           }
 
-          sprintf(resp, "%.*s", (int) id.len, id.chars);
+          sprintf(resp, "%.*s\n", (int) id.len, id.chars);
           if (write_to_pipe(tokens[2], resp))
           {
             pelz_log(LOG_DEBUG, "Unable to send response to pelz cmd.");
           }
         }
-        sleep (0.02);
-        if (write_to_pipe(tokens[2], (char *) "END"))
+        if (write_to_pipe(tokens[2], (char *) "END\n"))
         {
           pelz_log(LOG_DEBUG, "Unable to send response to pelz cmd.");
         }
@@ -196,7 +192,8 @@ void *fifo_thread_process(void *arg)
         }
         break;
       default:
-        if (write_to_pipe(tokens[2], (char *) resp_str[ret]))
+        sprintf(resp, "%s\n", resp_str[ret]);
+        if (write_to_pipe(tokens[2], resp))
         {
            pelz_log(LOG_DEBUG, "Unable to send response to pelz cmd.");
         }
@@ -204,8 +201,7 @@ void *fifo_thread_process(void *arg)
         {
           pelz_log(LOG_DEBUG, "Pelz-service responses sent to pelz cmd.");
         }
-        sleep (0.02);
-        if (write_to_pipe(tokens[2], (char *) "END"))
+        if (write_to_pipe(tokens[2], (char *) "END\n"))
         {
           pelz_log(LOG_DEBUG, "Unable to send response to pelz cmd.");
         }

--- a/src/util/pelz_thread.c
+++ b/src/util/pelz_thread.c
@@ -41,7 +41,7 @@ int send_table_id_list(char *pipe_name, TableType table_type, const char *resp_m
   table_id_count(eid, &status, table_type, &list_num);
   if (status != OK)
   {
-    pelz_log(LOG_ERR, "Error retrieving Key Table count.");
+    pelz_log(LOG_ERR, "Error retrieving table count.");
     close(fd);
     return 1;
   }
@@ -63,7 +63,7 @@ int send_table_id_list(char *pipe_name, TableType table_type, const char *resp_m
     table_id(eid, &status, table_type, count, &id);
     if (status != OK)
     {
-      pelz_log(LOG_ERR, "Error retrieving Key Table <ID> from index %d.", count);
+      pelz_log(LOG_ERR, "Error retrieving table <ID> from index %d.", count);
       err = 1;
       continue;
     }


### PR DESCRIPTION
* Use newline delimiter to separate response message components instead of using sleep delays to synchronize reads and writes (required some refactoring).
* Open response pipes for reading before sending commands (fixes a non-deterministic bug, required some refactoring).
* Handle incorrect `select` behavior (fixes a non-deterministic bug).
* Fix buffer overflows for command messages.
* Additional refactoring to avoid repeatedly re-opening the pipe file when sending response messages.

More info in the commit messages.