### PR TITLE
Improvement/refactor json parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,45 +38,31 @@ The JSON objects can be in two forms: requests and responses.
      * URI syntax must currently comply with RFC 8089 and RFC 1738 Section 3.1.
 * key\_id_len : int
     * Integer specifying the length of the key_id URI.
-* enc_data : string of characters
-    * Base64 encoded version of the unencrypted key to be AES Key Wrapped.
-* enc\_data_len : int
-    * Integer specifying the length of the base-64 encoded, unencrypted key.
-* dec_data : string of characters
-    * Base-64 encoded version of the encrypted key to be AES Key UnWrapped.
-* dec\_data_len : int
-     * Integer specifying the length of the base-64 encoded, encrypted key.
+* data : string of characters
+    * Base64 encoded version of the key to be wrapped or unwrapped.
 
 Examples:
 
 JSON Request for AES Key Wrap
-* {"key_id": "file:~/pelz/test/key1.txt", "request_type": 1, "enc_data_len": 33, "key_id_len": 37, "enc_data": "YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4\n"}
-* {"key_id": "pelz://localhost/7000/fake_key_id", "request_type": 1, "enc_data_len": 33, "key_id_len": 33, "enc_data": "YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4\n"}
+* {"key_id": "file:~/pelz/test/key1.txt", "request_type": 1, "data": "YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4\n"}
+* {"key_id": "pelz://localhost/7000/fake_key_id", "request_type": 1, "data": "YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4\n"}
 
 JSON Request for AES Key Unwrap
-* {"key_id": "file:~/pelz/test/key1.txt", "request_type": 2, "dec_data_len": 45, "key_id_len": 37, "dec_data": "BtIjIgvCaVBwUi5jTOZyIx2yJamqvrR0BZWLFVufz9w=\n"}
-* {"key_id": "pelz://localhost/7000/fake_key_id", "request_type": 2, "dec_data_len": 45, "key_id_len": 33, "dec_data": "BtIjIgvCaVBwUi5jTOZyIx2yJamqvrR0BZWLFVufz9w=\n"}
+* {"key_id": "file:~/pelz/test/key1.txt", "request_type": 2, "data": "BtIjIgvCaVBwUi5jTOZyIx2yJamqvrR0BZWLFVufz9w=\n"}
+* {"key_id": "pelz://localhost/7000/fake_key_id", "request_type": 2, "data": "BtIjIgvCaVBwUi5jTOZyIx2yJamqvrR0BZWLFVufz9w=\n"}
 
 #### Response JSON Key and Values
 * key_id : string of characters
     * URI for the key location (key identifier).
     * The key_id specified in the JSON request will be included in the JSON response.
-* key\_id_len : int
-    * Integer specifying the length of the key_id URI.
-* enc_out : string of characters
-    * Base-64 encoded, AES Key Wrapped key.
-* enc\_out_len : int
-    * Integer specifying the length of the base-64 encoded, encrypted key.
-* dec_out : string of characters
-    * Base-64 encoded, AES Key UnWrapped key.
-* dec\_out_len : int
-    * Integer specifying the length of the base-64 encoded, unencrypted key.
+* data : string of characters
+    * Base-64 encoded, output data.
 * error : string of characters
     * Error message for the service user
 
 Examples:
-* {"key_id": "file:~/pelz/test/key1.txt", "enc_out": "BtIjIgvCaVBwUi5jTOZyIx2yJamqvrR0BZWLFVufz9w=\n", "key_id_len": 37, "enc_out_len": 45}
-* {"key_id": "file:~/pelz/test/key1.txt", "dec_out": "YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4\n", "key_id_len": 37, "dec_out_len": 33}
+* {"key_id": "file:~/pelz/test/key1.txt", "enc_out": "BtIjIgvCaVBwUi5jTOZyIx2yJamqvrR0BZWLFVufz9w=\n"}
+* {"key_id": "file:~/pelz/test/key1.txt", "dec_out": "YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4\n"}
 * {"error': "Key not added"}
 
 ### URI Schemes

--- a/README.md
+++ b/README.md
@@ -36,10 +36,8 @@ The JSON objects can be in two forms: requests and responses.
 * key_id : string of characters
      * URI for the key location - used as the key identifier.
      * URI syntax must currently comply with RFC 8089 and RFC 1738 Section 3.1.
-* key\_id_len : int
-    * Integer specifying the length of the key_id URI.
 * data : string of characters
-    * Base64 encoded version of the key to be wrapped or unwrapped.
+    * Base64 encoded data to be processed based on request type.
 
 Examples:
 
@@ -56,7 +54,7 @@ JSON Request for AES Key Unwrap
     * URI for the key location (key identifier).
     * The key_id specified in the JSON request will be included in the JSON response.
 * data : string of characters
-    * Base-64 encoded, output data.
+    * Base-64 encoded, output data based on request type.
 * error : string of characters
     * Error message for the service user
 

--- a/src/util/pelz_json_parser.c
+++ b/src/util/pelz_json_parser.c
@@ -14,8 +14,7 @@
 
 /**
  * <pre>
- * Helper function to extract fields from JSON structs. The fields must have
- * an associated length field whose name is <field_name>_len.
+ * Helper function to extract string fields from JSON structs.
  * <pre>
  *
  * @param[in] json       The JSON structure.
@@ -52,8 +51,7 @@ static charbuf get_JSON_string_field(cJSON* json, const char* field_name)
 
 /**
  * <pre>
- * Helper function to extract fields from JSON structs. The fields must have
- * an associated length field whose name is <field_name>_len.
+ * Helper function to extract fields from JSON structs. 
  * <pre>
  *
  * @param[in]  json       The JSON structure.

--- a/src/util/pelz_json_parser.c
+++ b/src/util/pelz_json_parser.c
@@ -169,7 +169,7 @@ int message_encoder(RequestType request_type, charbuf key_id, charbuf data, char
 
     tmp = (char *) calloc((data.len + 1), sizeof(char));
     memcpy(tmp, data.chars, data.len);
-    cJSON_AddItemToObject(root, "enc_out", cJSON_CreateString(tmp));
+    cJSON_AddItemToObject(root, "data", cJSON_CreateString(tmp));
     free(tmp);
     break;
   case REQ_DEC:
@@ -180,7 +180,7 @@ int message_encoder(RequestType request_type, charbuf key_id, charbuf data, char
 
     tmp = (char *) calloc((data.len + 1), sizeof(char));
     memcpy(tmp, data.chars, data.len);
-    cJSON_AddItemToObject(root, "dec_out", cJSON_CreateString(tmp));
+    cJSON_AddItemToObject(root, "data", cJSON_CreateString(tmp));
     free(tmp);
     break;
   default:
@@ -210,7 +210,7 @@ int encrypt_parser(cJSON * json, charbuf * key_id, charbuf * data)
     free_charbuf(key_id);
     return 1;
   }
-  *data = get_JSON_string_field(json, "enc_data");
+  *data = get_JSON_string_field(json, "data");
   if(data->len == 0 || data->chars == NULL)
   {
     free_charbuf(key_id);
@@ -228,7 +228,7 @@ int decrypt_parser(cJSON * json, charbuf * key_id, charbuf * data)
     free_charbuf(key_id);
     return 1;
   }
-  *data = get_JSON_string_field(json, "dec_data");
+  *data = get_JSON_string_field(json, "data");
   if(data->len == 0 || data->chars == NULL)
   {
     free_charbuf(key_id);

--- a/src/util/pelz_json_parser.c
+++ b/src/util/pelz_json_parser.c
@@ -12,6 +12,68 @@
 #include <charbuf.h>
 #include <pelz_log.h>
 
+/**
+ * <pre>
+ * Helper function to extract fields from JSON structs. The fields must have
+ * an associated length field whose name is <field_name>_len.
+ * <pre>
+ *
+ * @param[in] json       The JSON structure.
+ * @param[in] field_name The name of the desired field.
+ *
+ * @return A charbuf containing the data from the field, or a charbuf
+ *         of length 0 on error.
+ */
+static charbuf get_JSON_string_field(cJSON* json, const char* field_name)
+{
+  charbuf field;
+  if(!cJSON_HasObjectItem(json, field_name) || !cJSON_IsString(cJSON_GetObjectItem(json, field_name)))
+  {
+    pelz_log(LOG_ERR, "Missing JSON field %s.", field_name);
+    return new_charbuf(0);
+  } 
+  if(cJSON_GetObjectItemCaseSensitive(json, field_name)->valuestring != NULL)
+  {
+    field = new_charbuf(strlen(cJSON_GetObjectItemCaseSensitive(json, field_name)->valuestring));
+    if(field.len == 0 || field.chars == NULL)
+    {  
+      pelz_log(LOG_ERR, "Failed to allocate memory to extract JSON field %s.", field_name);
+      return new_charbuf(0);
+    }
+    memcpy(field.chars, cJSON_GetObjectItemCaseSensitive(json, field_name)->valuestring, field.len);
+  }
+  else
+  {
+    pelz_log(LOG_ERR, "No value in JSON field %s.", field_name);
+    return new_charbuf(0);
+  }
+  return field;
+}
+
+/**
+ * <pre>
+ * Helper function to extract fields from JSON structs. The fields must have
+ * an associated length field whose name is <field_name>_len.
+ * <pre>
+ *
+ * @param[in]  json       The JSON structure.
+ * @param[in]  field_name The name of the desired field.
+ * @param[out] value      Integer pointer to hold the extracted value.
+ *
+ * @return 0 on success, 1 error
+ */
+static int get_JSON_int_field(cJSON* json, const char* field_name, int* value)
+{
+  if(!cJSON_HasObjectItem(json, field_name) || !cJSON_IsNumber(cJSON_GetObjectItem(json, field_name)))
+  {
+    pelz_log(LOG_ERR, "Missing JSON field %s.", field_name);
+    return 1;
+  }
+  *value = cJSON_GetObjectItemCaseSensitive(json, field_name)->valueint;
+  return 0;
+}
+
+
 int request_decoder(charbuf request, RequestType * request_type, charbuf * key_id, charbuf * data, charbuf * request_sig, charbuf * requestor_cert)
 {
   cJSON *json;
@@ -21,19 +83,13 @@ int request_decoder(charbuf request, RequestType * request_type, charbuf * key_i
   memcpy(str, request.chars, request.len);
   json = cJSON_Parse(str);
   free(str);
-  if (!cJSON_HasObjectItem(json, "request_type"))
+  if(get_JSON_int_field(json, "request_type", (int*)request_type))
   {
     pelz_log(LOG_ERR, "Missing required JSON key: request_type.");
     cJSON_Delete(json);
     return (1);
   }
-  else if (!cJSON_IsNumber(cJSON_GetObjectItem(json, "request_type")))
-  {
-    pelz_log(LOG_ERR, "Incorrect data type of JSON value of JSON key: request_type. Data type should be integer.");
-    cJSON_Delete(json);
-    return (1);
-  }
-  *request_type = (RequestType) cJSON_GetObjectItemCaseSensitive(json, "request_type")->valueint;
+
   switch (*request_type)
   {    
   case REQ_ENC:

--- a/src/util/pelz_json_parser.c
+++ b/src/util/pelz_json_parser.c
@@ -168,24 +168,22 @@ int message_encoder(RequestType request_type, charbuf key_id, charbuf data, char
     memcpy(tmp, key_id.chars, key_id.len);
     cJSON_AddItemToObject(root, "key_id", cJSON_CreateString(tmp));
     free(tmp);
-    cJSON_AddItemToObject(root, "key_id_len", cJSON_CreateNumber(key_id.len));
+
     tmp = (char *) calloc((data.len + 1), sizeof(char));
     memcpy(tmp, data.chars, data.len);
     cJSON_AddItemToObject(root, "enc_out", cJSON_CreateString(tmp));
     free(tmp);
-    cJSON_AddItemToObject(root, "enc_out_len", cJSON_CreateNumber(data.len));
     break;
   case REQ_DEC:
     tmp = (char *) calloc((key_id.len + 1), sizeof(char));
     memcpy(tmp, key_id.chars, key_id.len);
     cJSON_AddItemToObject(root, "key_id", cJSON_CreateString(tmp));
     free(tmp);
-    cJSON_AddItemToObject(root, "key_id_len", cJSON_CreateNumber(key_id.len));
+
     tmp = (char *) calloc((data.len + 1), sizeof(char));
     memcpy(tmp, data.chars, data.len);
     cJSON_AddItemToObject(root, "dec_out", cJSON_CreateString(tmp));
     free(tmp);
-    cJSON_AddItemToObject(root, "dec_out_len", cJSON_CreateNumber(data.len));
     break;
   default:
     pelz_log(LOG_ERR, "Request Type not recognized.");

--- a/src/util/pelz_json_parser.c
+++ b/src/util/pelz_json_parser.c
@@ -244,86 +244,19 @@ int decrypt_parser(cJSON * json, charbuf * key_id, charbuf * data)
 
 int signed_parser(cJSON * json, charbuf * request_sig, charbuf * requestor_cert)
 {
-  if (!cJSON_HasObjectItem(json, "request_sig"))
+  *request_sig = get_JSON_string_field(json, "request_sig");
+  if(request_sig->len == 0 || request_sig->chars == NULL)
   {
-    pelz_log(LOG_ERR, "Missing required JSON key: request_sig.");
-    return (1);
-  }
-  else if (!cJSON_HasObjectItem(json, "request_sig_len"))
-  {
-    pelz_log(LOG_ERR, "Missing required JSON key: request_sig_len.");
-    return (1);
-  }
-  else if (!cJSON_HasObjectItem(json, "requestor_cert"))
-  {
-    pelz_log(LOG_ERR, "Missing required JSON key: requestor_cert.");
-    return (1);
-  }
-  else if (!cJSON_HasObjectItem(json, "requestor_cert_len"))
-  {
-    pelz_log(LOG_ERR, "Missing required JSON key: requestor_cert_len.");
-    return (1);
-  }
-  
-  if (!cJSON_IsNumber(cJSON_GetObjectItem(json, "request_sig_len")))
-  {
-    pelz_log(LOG_ERR, "Incorrect data type of JSON value of JSON key: request_sig_len. Data type should be integer.");
-    return (1);
-  }
-  *request_sig = new_charbuf(cJSON_GetObjectItemCaseSensitive(json, "request_sig_len")->valueint);
-  if (!cJSON_IsString(cJSON_GetObjectItem(json, "request_sig")))
-  {
-    pelz_log(LOG_ERR, "Incorrect data type of JSON value of JSON key: request_sig. Data type should be string.");
     free_charbuf(request_sig);
-    return (1);
+    return 1;
   }
-  if (cJSON_GetObjectItemCaseSensitive(json, "request_sig")->valuestring != NULL)
+
+  *requestor_cert = get_JSON_string_field(json, "requestor_cert");
+  if(requestor_cert->len == 0 || requestor_cert->chars == NULL)
   {
-    if (strlen(cJSON_GetObjectItemCaseSensitive(json, "request_sig")->valuestring) != request_sig->len)
-    {     
-      pelz_log(LOG_ERR, "Length of value in JSON key: request_sig does not match value in JSON key: request_sig_len.");
-      free_charbuf(request_sig);
-      return (1);
-    }
-    memcpy(request_sig->chars, cJSON_GetObjectItemCaseSensitive(json, "request_sig")->valuestring, request_sig->len);
-  }
-  else
-  {
-    pelz_log(LOG_ERR, "No value in JSON key: request_sig.");
-    free_charbuf(request_sig);
-    return (1);
-  }
-  if (!cJSON_IsNumber(cJSON_GetObjectItem(json, "requestor_cert_len")))
-  {
-    pelz_log(LOG_ERR, "Incorrect data type of JSON value of JSON key: requestor_cert_len. Data type should be integer.");
-    free_charbuf(request_sig);
-    return (1);
-  }
-  *requestor_cert = new_charbuf(cJSON_GetObjectItemCaseSensitive(json, "requestor_cert_len")->valueint);
-  if (!cJSON_IsString(cJSON_GetObjectItem(json, "requestor_cert")))
-  {
-    pelz_log(LOG_ERR, "Incorrect data type of JSON value of JSON key: requestor_cert. Data type should be string.");
     free_charbuf(request_sig);
     free_charbuf(requestor_cert);
-    return (1);
-  }
-  if (cJSON_GetObjectItemCaseSensitive(json, "requestor_cert")->valuestring != NULL)
-  {
-    if (strlen(cJSON_GetObjectItemCaseSensitive(json, "requestor_cert")->valuestring) != requestor_cert->len)
-    {
-      pelz_log(LOG_ERR, "Length of value in JSON key: requestor_cert does not match value in JSON key: requestor_cert_len.");
-      free_charbuf(request_sig);
-      free_charbuf(requestor_cert);
-      return (1);
-    }
-    memcpy(requestor_cert->chars, cJSON_GetObjectItemCaseSensitive(json, "requestor_cert")->valuestring, requestor_cert->len);
-  }
-  else
-  {
-    pelz_log(LOG_ERR, "No value in JSON key: requestor_cert.");
-    free_charbuf(request_sig);
-    free_charbuf(requestor_cert);
-    return (1);
+    return 1;
   }
   return (0);
 }

--- a/src/util/pelz_json_parser.c
+++ b/src/util/pelz_json_parser.c
@@ -211,11 +211,14 @@ int encrypt_parser(cJSON * json, charbuf * key_id, charbuf * data)
   *key_id = get_JSON_string_field(json, "key_id");
   if(key_id->len == 0 || key_id->chars == NULL)
   {
+    free_charbuf(key_id);
     return 1;
   }
   *data = get_JSON_string_field(json, "enc_data");
   if(data->len == 0 || data->chars == NULL)
   {
+    free_charbuf(key_id);
+    free_charbuf(data);
     return 1;
   }
   return (0);
@@ -223,85 +226,18 @@ int encrypt_parser(cJSON * json, charbuf * key_id, charbuf * data)
 
 int decrypt_parser(cJSON * json, charbuf * key_id, charbuf * data)
 {
-  if (!cJSON_HasObjectItem(json, "key_id"))
+  *key_id = get_JSON_string_field(json, "key_id");
+  if(key_id->len == 0 || key_id->chars == NULL)
   {
-    pelz_log(LOG_ERR, "Missing required JSON key: key_id.");
-    return (1);
-  }
-  else if (!cJSON_HasObjectItem(json, "key_id_len"))
-  {
-    pelz_log(LOG_ERR, "Missing required JSON key: key_id_len.");
-    return (1);
-  }
-  else if (!cJSON_HasObjectItem(json, "dec_data"))
-  {
-    pelz_log(LOG_ERR, "Missing required JSON key: dec_data.");
-    return (1);
-  }
-  else if (!cJSON_HasObjectItem(json, "dec_data_len"))
-  {
-    pelz_log(LOG_ERR, "Missing required JSON key: dec_data_len.");
-    return (1);
-  }
-  if (!cJSON_IsNumber(cJSON_GetObjectItem(json, "key_id_len")))
-  {
-    pelz_log(LOG_ERR, "Incorrect data type of JSON value of JSON key: key_id_len. Data type should be integer.");
-    return (1);
-  }
-  *key_id = new_charbuf(cJSON_GetObjectItemCaseSensitive(json, "key_id_len")->valueint);
-  if (!cJSON_IsString(cJSON_GetObjectItem(json, "key_id")))
-  {
-    pelz_log(LOG_ERR, "Incorrect data type of JSON value of JSON key: key_id. Data type should be string.");
     free_charbuf(key_id);
-    return (1);
+    return 1;
   }
-  if (cJSON_GetObjectItemCaseSensitive(json, "key_id")->valuestring != NULL)
+  *data = get_JSON_string_field(json, "dec_data");
+  if(data->len == 0 || data->chars == NULL)
   {
-    if (strlen(cJSON_GetObjectItemCaseSensitive(json, "key_id")->valuestring) != key_id->len)
-    {
-      pelz_log(LOG_ERR, "Length of value in JSON key: key_id does not match value in JSON key: key_id_len.");
-      free_charbuf(key_id);
-      return (1);
-    }
-    memcpy(key_id->chars, cJSON_GetObjectItemCaseSensitive(json, "key_id")->valuestring, key_id->len);
-  }
-  else
-  {
-    pelz_log(LOG_ERR, "No value in JSON key: key_id.");
-    free_charbuf(key_id);
-    return (1);
-  }
-  if (!cJSON_IsNumber(cJSON_GetObjectItem(json, "dec_data_len")))
-  {
-    pelz_log(LOG_ERR, "Incorrect data type of JSON value of JSON key: dec_data_len. Data type should be integer.");
-    free_charbuf(key_id);
-    return (1);
-  }
-  *data = new_charbuf(cJSON_GetObjectItemCaseSensitive(json, "dec_data_len")->valueint);
-  if (!cJSON_IsString(cJSON_GetObjectItem(json, "dec_data")))
-  {
-    pelz_log(LOG_ERR, "Incorrect data type of JSON value of JSON key: dec_data. Data type should be string.");
     free_charbuf(key_id);
     free_charbuf(data);
-    return (1);
-  }
-  if (cJSON_GetObjectItemCaseSensitive(json, "dec_data")->valuestring != NULL)
-  {
-    if (strlen(cJSON_GetObjectItemCaseSensitive(json, "dec_data")->valuestring) != data->len)
-    {
-      pelz_log(LOG_ERR, "Length of value in JSON key: dec_data does not match value in JSON key: dec_data_len.");
-      free_charbuf(key_id);
-      free_charbuf(data);
-      return (1);
-    }
-    memcpy(data->chars, cJSON_GetObjectItemCaseSensitive(json, "dec_data")->valuestring, data->len);
-  }
-  else
-  {
-    pelz_log(LOG_ERR, "No value in JSON key: dec_data.");
-    free_charbuf(key_id);
-    free_charbuf(data);
-    return (1);
+    return 1;
   }
   return (0);
 }

--- a/src/util/pelz_json_parser.c
+++ b/src/util/pelz_json_parser.c
@@ -100,7 +100,7 @@ int request_decoder(charbuf request, RequestType * request_type, charbuf * key_i
   }
 
   *data = get_JSON_string_field(json, "data");
-  if(data->len == 0 || data->chars = NULL)
+  if(data->len == 0 || data->chars == NULL)
   {
     pelz_log(LOG_ERR, "Failed to exract data from JSON.");
     cJSON_Delete(json);

--- a/src/util/pelz_json_parser.c
+++ b/src/util/pelz_json_parser.c
@@ -208,85 +208,15 @@ int message_encoder(RequestType request_type, charbuf key_id, charbuf data, char
 
 int encrypt_parser(cJSON * json, charbuf * key_id, charbuf * data)
 {
-  if (!cJSON_HasObjectItem(json, "key_id"))
+  *key_id = get_JSON_string_field(json, "key_id");
+  if(key_id->len == 0 || key_id->chars == NULL)
   {
-    pelz_log(LOG_ERR, "Missing required JSON key: key_id.");
-    return (1);
+    return 1;
   }
-  else if (!cJSON_HasObjectItem(json, "key_id_len"))
+  *data = get_JSON_string_field(json, "enc_data");
+  if(data->len == 0 || data->chars == NULL)
   {
-    pelz_log(LOG_ERR, "Missing required JSON key: key_id_len.");
-    return (1);
-  }
-  else if (!cJSON_HasObjectItem(json, "enc_data"))
-  {
-    pelz_log(LOG_ERR, "Missing required JSON key: enc_data.");
-    return (1);
-  }
-  else if (!cJSON_HasObjectItem(json, "enc_data_len"))
-  {
-    pelz_log(LOG_ERR, "Missing required JSON key: enc_data_len.");
-    return (1);
-  }
-  if (!cJSON_IsNumber(cJSON_GetObjectItem(json, "key_id_len")))
-  {
-    pelz_log(LOG_ERR, "Incorrect data type of JSON value of JSON key: key_id_len. Data type should be integer.");
-    return (1);
-  }
-  *key_id = new_charbuf(cJSON_GetObjectItemCaseSensitive(json, "key_id_len")->valueint);
-  if (!cJSON_IsString(cJSON_GetObjectItem(json, "key_id")))
-  {
-    pelz_log(LOG_ERR, "Incorrect data type of JSON value of JSON key: key_id. Data type should be string.");
-    free_charbuf(key_id);
-    return (1);
-  }
-  if (cJSON_GetObjectItemCaseSensitive(json, "key_id")->valuestring != NULL)
-  {
-    if (strlen(cJSON_GetObjectItemCaseSensitive(json, "key_id")->valuestring) != key_id->len)
-    {
-      pelz_log(LOG_ERR, "Length of value in JSON key: key_id does not match value in JSON key: key_id_len.");
-      free_charbuf(key_id);
-      return (1);
-    }
-    memcpy(key_id->chars, cJSON_GetObjectItemCaseSensitive(json, "key_id")->valuestring, key_id->len);
-  }
-  else
-  {
-    pelz_log(LOG_ERR, "No value in JSON key: key_id.");
-    free_charbuf(key_id);
-    return (1);
-  }
-  if (!cJSON_IsNumber(cJSON_GetObjectItem(json, "enc_data_len")))
-  {
-    pelz_log(LOG_ERR, "Incorrect data type of JSON value of JSON key: enc_data_len. Data type should be integer.");
-    free_charbuf(key_id);
-    return (1);
-  }
-  *data = new_charbuf(cJSON_GetObjectItemCaseSensitive(json, "enc_data_len")->valueint);
-  if (!cJSON_IsString(cJSON_GetObjectItem(json, "enc_data")))
-  {
-    pelz_log(LOG_ERR, "Incorrect data type of JSON value of JSON key: enc_data. Data type should be string.");
-    free_charbuf(key_id);
-    free_charbuf(data);
-    return (1);
-  }
-  if (cJSON_GetObjectItemCaseSensitive(json, "enc_data")->valuestring != NULL)
-  {
-    if (strlen(cJSON_GetObjectItemCaseSensitive(json, "enc_data")->valuestring) != data->len)
-    {
-      pelz_log(LOG_ERR, "Length of value in JSON key: enc_data does not match value in JSON key: enc_data_len.");
-      free_charbuf(key_id);
-      free_charbuf(data);
-      return (1);
-    }
-    memcpy(data->chars, cJSON_GetObjectItemCaseSensitive(json, "enc_data")->valuestring, data->len);
-  }
-  else
-  {
-    pelz_log(LOG_ERR, "No value in JSON key: enc_data.");
-    free_charbuf(key_id);
-    free_charbuf(data);
-    return (1);
+    return 1;
   }
   return (0);
 }

--- a/test/src/util/pelz_json_parser_test_suite.c
+++ b/test/src/util/pelz_json_parser_test_suite.c
@@ -372,18 +372,18 @@ void test_message_encoder(void)
   charbuf message;
   const char *test[5] = { "file:/test/key1.txt", "test/key1.txt", "file", "anything", "" };
   const char *valid_enc_message[5] =
-    { "{\"key_id\":\"file:/test/key1.txt\",\"key_id_len\":19,\"enc_out\":\"SwqqSZbNtN2SOfKGtE2jfklrcARSCZE9Tdl93pggkIsRkY3MrjevmQ==\\n\",\"enc_out_len\":57}",
-    "{\"key_id\":\"test/key1.txt\",\"key_id_len\":13,\"enc_out\":\"SwqqSZbNtN2SOfKGtE2jfklrcARSCZE9Tdl93pggkIsRkY3MrjevmQ==\\n\",\"enc_out_len\":57}",
-    "{\"key_id\":\"file\",\"key_id_len\":4,\"enc_out\":\"SwqqSZbNtN2SOfKGtE2jfklrcARSCZE9Tdl93pggkIsRkY3MrjevmQ==\\n\",\"enc_out_len\":57}",
-    "{\"key_id\":\"anything\",\"key_id_len\":8,\"enc_out\":\"SwqqSZbNtN2SOfKGtE2jfklrcARSCZE9Tdl93pggkIsRkY3MrjevmQ==\\n\",\"enc_out_len\":57}",
-    "{\"key_id\":\"\",\"key_id_len\":0,\"enc_out\":\"SwqqSZbNtN2SOfKGtE2jfklrcARSCZE9Tdl93pggkIsRkY3MrjevmQ==\\n\",\"enc_out_len\":57}"
+    { "{\"key_id\":\"file:/test/key1.txt\",\"enc_out\":\"SwqqSZbNtN2SOfKGtE2jfklrcARSCZE9Tdl93pggkIsRkY3MrjevmQ==\\n\"}",
+    "{\"key_id\":\"test/key1.txt\",\"enc_out\":\"SwqqSZbNtN2SOfKGtE2jfklrcARSCZE9Tdl93pggkIsRkY3MrjevmQ==\\n\"}",
+    "{\"key_id\":\"file\",\"enc_out\":\"SwqqSZbNtN2SOfKGtE2jfklrcARSCZE9Tdl93pggkIsRkY3MrjevmQ==\\n\"}",
+    "{\"key_id\":\"anything\",\"enc_out\":\"SwqqSZbNtN2SOfKGtE2jfklrcARSCZE9Tdl93pggkIsRkY3MrjevmQ==\\n\"}",
+    "{\"key_id\":\"\",\"enc_out\":\"SwqqSZbNtN2SOfKGtE2jfklrcARSCZE9Tdl93pggkIsRkY3MrjevmQ==\\n\"}"
   };
   const char *valid_dec_message[5] =
-    { "{\"key_id\":\"file:/test/key1.txt\",\"key_id_len\":19,\"dec_out\":\"SwqqSZbNtN2SOfKGtE2jfklrcARSCZE9Tdl93pggkIsRkY3MrjevmQ==\\n\",\"dec_out_len\":57}",
-    "{\"key_id\":\"test/key1.txt\",\"key_id_len\":13,\"dec_out\":\"SwqqSZbNtN2SOfKGtE2jfklrcARSCZE9Tdl93pggkIsRkY3MrjevmQ==\\n\",\"dec_out_len\":57}",
-    "{\"key_id\":\"file\",\"key_id_len\":4,\"dec_out\":\"SwqqSZbNtN2SOfKGtE2jfklrcARSCZE9Tdl93pggkIsRkY3MrjevmQ==\\n\",\"dec_out_len\":57}",
-    "{\"key_id\":\"anything\",\"key_id_len\":8,\"dec_out\":\"SwqqSZbNtN2SOfKGtE2jfklrcARSCZE9Tdl93pggkIsRkY3MrjevmQ==\\n\",\"dec_out_len\":57}",
-    "{\"key_id\":\"\",\"key_id_len\":0,\"dec_out\":\"SwqqSZbNtN2SOfKGtE2jfklrcARSCZE9Tdl93pggkIsRkY3MrjevmQ==\\n\",\"dec_out_len\":57}"
+    { "{\"key_id\":\"file:/test/key1.txt\",\"dec_out\":\"SwqqSZbNtN2SOfKGtE2jfklrcARSCZE9Tdl93pggkIsRkY3MrjevmQ==\\n\"}",
+    "{\"key_id\":\"test/key1.txt\",\"dec_out\":\"SwqqSZbNtN2SOfKGtE2jfklrcARSCZE9Tdl93pggkIsRkY3MrjevmQ==\\n\"}",
+    "{\"key_id\":\"file\",\"dec_out\":\"SwqqSZbNtN2SOfKGtE2jfklrcARSCZE9Tdl93pggkIsRkY3MrjevmQ==\\n\"}",
+    "{\"key_id\":\"anything\",\"dec_out\":\"SwqqSZbNtN2SOfKGtE2jfklrcARSCZE9Tdl93pggkIsRkY3MrjevmQ==\\n\"}",
+    "{\"key_id\":\"\",\"dec_out\":\"SwqqSZbNtN2SOfKGtE2jfklrcARSCZE9Tdl93pggkIsRkY3MrjevmQ==\\n\"}"
   };
   
   //Start Message Encoder Test

--- a/test/src/util/pelz_json_parser_test_suite.c
+++ b/test/src/util/pelz_json_parser_test_suite.c
@@ -51,14 +51,12 @@ void test_encrypt_parser(void)
   unsigned int json_key_id_len = 19;
   const char *enc_data = "QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVoxMjM0NTY=\n";
   unsigned int enc_data_len = 45;
-  const char *dec_data = "SwqqSZbNtN2SOfKGtE2jfklrcARSCZE9Tdl93pggkIsRkY3MrjevmQ==\n";
 
   //Building of a standard valid JSON request
   json = cJSON_CreateObject();
   cJSON_AddItemToObject(json, "request_type", cJSON_CreateNumber(1));
   cJSON_AddItemToObject(json, "key_id", cJSON_CreateString(json_key_id));
-  cJSON_AddItemToObject(json, "enc_data", cJSON_CreateString(enc_data));
-  cJSON_AddItemToObject(json, "dec_data", cJSON_CreateString(dec_data));
+  cJSON_AddItemToObject(json, "data", cJSON_CreateString(enc_data));
                        
   //Test standard valid JSON request
   CU_ASSERT(encrypt_parser(json, &key_id, &data) == 0);
@@ -74,16 +72,10 @@ void test_encrypt_parser(void)
   CU_ASSERT(encrypt_parser(json, &key_id, &data) == 1);
   cJSON_AddItemToObject(json, "key_id", cJSON_CreateString(json_key_id));
 
-  cJSON_DeleteItemFromObject(json, "enc_data");
+  cJSON_DeleteItemFromObject(json, "data");
   CU_ASSERT(encrypt_parser(json, &key_id, &data) == 1);
-  cJSON_AddItemToObject(json, "enc_data", cJSON_CreateString(enc_data));
-
-  cJSON_DeleteItemFromObject(json, "dec_data");
+  cJSON_AddItemToObject(json, "data", cJSON_CreateString(enc_data));
   CU_ASSERT(encrypt_parser(json, &key_id, &data) == 0);
-  // Do we have to deallocate right here, every time we call encrypt_parser(), or just at the end of it all?
-  free_charbuf(&key_id);
-  free_charbuf(&data);
-  cJSON_AddItemToObject(json, "dec_data", cJSON_CreateString(dec_data));
 
   free_charbuf(&key_id);
   free_charbuf(&data);
@@ -95,11 +87,11 @@ void test_encrypt_parser(void)
   cJSON_DeleteItemFromObject(json, "key_id");
   cJSON_AddItemToObject(json, "key_id", cJSON_CreateString(json_key_id));
 
-  cJSON_DeleteItemFromObject(json, "enc_data");
-  cJSON_AddItemToObject(json, "enc_data", cJSON_CreateNumber(6842));
+  cJSON_DeleteItemFromObject(json, "data");
+  cJSON_AddItemToObject(json, "data", cJSON_CreateNumber(6842));
   CU_ASSERT(encrypt_parser(json, &key_id, &data) == 1);
-  cJSON_DeleteItemFromObject(json, "enc_data");
-  cJSON_AddItemToObject(json, "enc_data", cJSON_CreateString(enc_data));
+  cJSON_DeleteItemFromObject(json, "data");
+  cJSON_AddItemToObject(json, "data", cJSON_CreateString(enc_data));
 
   //Clean-up JSON
   cJSON_Delete(json);
@@ -114,7 +106,6 @@ void test_decrypt_parser(void)
   //Valid Test Values
   const char *json_key_id = "file:/test/key1.txt";
   unsigned int json_key_id_len = 19;
-  const char *enc_data = "QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVoxMjM0NTY=\n";
   const char *dec_data = "SwqqSZbNtN2SOfKGtE2jfklrcARSCZE9Tdl93pggkIsRkY3MrjevmQ==\n";
   unsigned int dec_data_len = 57;
 
@@ -122,8 +113,7 @@ void test_decrypt_parser(void)
   json = cJSON_CreateObject();
   cJSON_AddItemToObject(json, "request_type", cJSON_CreateNumber(2));
   cJSON_AddItemToObject(json, "key_id", cJSON_CreateString(json_key_id));
-  cJSON_AddItemToObject(json, "enc_data", cJSON_CreateString(enc_data));
-  cJSON_AddItemToObject(json, "dec_data", cJSON_CreateString(dec_data));
+  cJSON_AddItemToObject(json, "data", cJSON_CreateString(dec_data));
 
   //Test standard valid JSON request
   CU_ASSERT(decrypt_parser(json, &key_id, &data) == 0);
@@ -139,15 +129,9 @@ void test_decrypt_parser(void)
   CU_ASSERT(decrypt_parser(json, &key_id, &data) == 1);
   cJSON_AddItemToObject(json, "key_id", cJSON_CreateString(json_key_id));
 
-  cJSON_DeleteItemFromObject(json, "dec_data");
+  cJSON_DeleteItemFromObject(json, "data");
   CU_ASSERT(decrypt_parser(json, &key_id, &data) == 1);
-  cJSON_AddItemToObject(json, "dec_data", cJSON_CreateString(dec_data));
-
-  cJSON_DeleteItemFromObject(json, "enc_data");
-  CU_ASSERT(decrypt_parser(json, &key_id, &data) == 0);
-  free_charbuf(&key_id);
-  free_charbuf(&data);
-  cJSON_AddItemToObject(json, "enc_data", cJSON_CreateString(enc_data));
+  cJSON_AddItemToObject(json, "data", cJSON_CreateString(dec_data));
 
   free_charbuf(&key_id);
   free_charbuf(&data);
@@ -159,11 +143,11 @@ void test_decrypt_parser(void)
   cJSON_DeleteItemFromObject(json, "key_id");
   cJSON_AddItemToObject(json, "key_id", cJSON_CreateString(json_key_id));
 
-  cJSON_DeleteItemFromObject(json, "dec_data");
-  cJSON_AddItemToObject(json, "dec_data", cJSON_CreateNumber(6842));
+  cJSON_DeleteItemFromObject(json, "data");
+  cJSON_AddItemToObject(json, "data", cJSON_CreateNumber(6842));
   CU_ASSERT(decrypt_parser(json, &key_id, &data) == 1);
-  cJSON_DeleteItemFromObject(json, "dec_data");
-  cJSON_AddItemToObject(json, "dec_data", cJSON_CreateString(dec_data));
+  cJSON_DeleteItemFromObject(json, "data");
+  cJSON_AddItemToObject(json, "data", cJSON_CreateString(dec_data));
 
   //Clean-up JSON
   cJSON_Delete(json);
@@ -259,9 +243,8 @@ void test_request_decoder(void)
   {
     cJSON_AddItemToObject(json_enc, "key_id", cJSON_CreateString(json_key_id[i]));
     cJSON_AddItemToObject(json_dec, "key_id", cJSON_CreateString(json_key_id[i]));
-    cJSON_AddItemToObject(json_enc, "enc_data", cJSON_CreateString(enc_data[i]));
-    cJSON_AddItemToObject(json_dec, "dec_data", cJSON_CreateString(dec_data[i]));
-
+    cJSON_AddItemToObject(json_enc, "data", cJSON_CreateString(enc_data[i]));
+    cJSON_AddItemToObject(json_dec, "data", cJSON_CreateString(dec_data[i]));
     //Creating the request charbuf for the JSON then testing request_decoder for encryption
     tmp = cJSON_PrintUnformatted(json_enc);
     request = new_charbuf(strlen(tmp));
@@ -296,16 +279,16 @@ void test_request_decoder(void)
     free_charbuf(&data);
 
     //Free the cJSON Objects to allow the addition of the next Object per the loop
-    cJSON_DeleteItemFromObject(json_dec, "dec_data");
-    cJSON_DeleteItemFromObject(json_enc, "enc_data");
+    cJSON_DeleteItemFromObject(json_dec, "data");
+    cJSON_DeleteItemFromObject(json_enc, "data");
     cJSON_DeleteItemFromObject(json_enc, "key_id");
     cJSON_DeleteItemFromObject(json_dec, "key_id");
   }
     // In the future these values will have to align with the validation() function
     cJSON_AddItemToObject(json_enc_signed, "key_id", cJSON_CreateString("file:/test/key1.txt"));
     cJSON_AddItemToObject(json_dec_signed, "key_id", cJSON_CreateString("file:/test/key1.txt"));
-    cJSON_AddItemToObject(json_enc_signed, "enc_data", cJSON_CreateString("TestData\n"));
-    cJSON_AddItemToObject(json_dec_signed, "dec_data", cJSON_CreateString("TestData\n"));
+    cJSON_AddItemToObject(json_enc_signed, "data", cJSON_CreateString("TestData\n"));
+    cJSON_AddItemToObject(json_dec_signed, "data", cJSON_CreateString("TestData\n"));
     cJSON_AddItemToObject(json_enc_signed, "request_sig", cJSON_CreateString("ValueEncrypt\n"));
     cJSON_AddItemToObject(json_enc_signed, "requestor_cert", cJSON_CreateString("ValueEncrypt2\n"));
     cJSON_AddItemToObject(json_dec_signed, "request_sig", cJSON_CreateString("ValueEncrypt\n"));
@@ -370,18 +353,18 @@ void test_message_encoder(void)
   charbuf message;
   const char *test[5] = { "file:/test/key1.txt", "test/key1.txt", "file", "anything", "" };
   const char *valid_enc_message[5] =
-    { "{\"key_id\":\"file:/test/key1.txt\",\"enc_out\":\"SwqqSZbNtN2SOfKGtE2jfklrcARSCZE9Tdl93pggkIsRkY3MrjevmQ==\\n\"}",
-    "{\"key_id\":\"test/key1.txt\",\"enc_out\":\"SwqqSZbNtN2SOfKGtE2jfklrcARSCZE9Tdl93pggkIsRkY3MrjevmQ==\\n\"}",
-    "{\"key_id\":\"file\",\"enc_out\":\"SwqqSZbNtN2SOfKGtE2jfklrcARSCZE9Tdl93pggkIsRkY3MrjevmQ==\\n\"}",
-    "{\"key_id\":\"anything\",\"enc_out\":\"SwqqSZbNtN2SOfKGtE2jfklrcARSCZE9Tdl93pggkIsRkY3MrjevmQ==\\n\"}",
-    "{\"key_id\":\"\",\"enc_out\":\"SwqqSZbNtN2SOfKGtE2jfklrcARSCZE9Tdl93pggkIsRkY3MrjevmQ==\\n\"}"
+    { "{\"key_id\":\"file:/test/key1.txt\",\"data\":\"SwqqSZbNtN2SOfKGtE2jfklrcARSCZE9Tdl93pggkIsRkY3MrjevmQ==\\n\"}",
+    "{\"key_id\":\"test/key1.txt\",\"data\":\"SwqqSZbNtN2SOfKGtE2jfklrcARSCZE9Tdl93pggkIsRkY3MrjevmQ==\\n\"}",
+    "{\"key_id\":\"file\",\"data\":\"SwqqSZbNtN2SOfKGtE2jfklrcARSCZE9Tdl93pggkIsRkY3MrjevmQ==\\n\"}",
+    "{\"key_id\":\"anything\",\"data\":\"SwqqSZbNtN2SOfKGtE2jfklrcARSCZE9Tdl93pggkIsRkY3MrjevmQ==\\n\"}",
+    "{\"key_id\":\"\",\"data\":\"SwqqSZbNtN2SOfKGtE2jfklrcARSCZE9Tdl93pggkIsRkY3MrjevmQ==\\n\"}"
   };
   const char *valid_dec_message[5] =
-    { "{\"key_id\":\"file:/test/key1.txt\",\"dec_out\":\"SwqqSZbNtN2SOfKGtE2jfklrcARSCZE9Tdl93pggkIsRkY3MrjevmQ==\\n\"}",
-    "{\"key_id\":\"test/key1.txt\",\"dec_out\":\"SwqqSZbNtN2SOfKGtE2jfklrcARSCZE9Tdl93pggkIsRkY3MrjevmQ==\\n\"}",
-    "{\"key_id\":\"file\",\"dec_out\":\"SwqqSZbNtN2SOfKGtE2jfklrcARSCZE9Tdl93pggkIsRkY3MrjevmQ==\\n\"}",
-    "{\"key_id\":\"anything\",\"dec_out\":\"SwqqSZbNtN2SOfKGtE2jfklrcARSCZE9Tdl93pggkIsRkY3MrjevmQ==\\n\"}",
-    "{\"key_id\":\"\",\"dec_out\":\"SwqqSZbNtN2SOfKGtE2jfklrcARSCZE9Tdl93pggkIsRkY3MrjevmQ==\\n\"}"
+    { "{\"key_id\":\"file:/test/key1.txt\",\"data\":\"SwqqSZbNtN2SOfKGtE2jfklrcARSCZE9Tdl93pggkIsRkY3MrjevmQ==\\n\"}",
+    "{\"key_id\":\"test/key1.txt\",\"data\":\"SwqqSZbNtN2SOfKGtE2jfklrcARSCZE9Tdl93pggkIsRkY3MrjevmQ==\\n\"}",
+    "{\"key_id\":\"file\",\"data\":\"SwqqSZbNtN2SOfKGtE2jfklrcARSCZE9Tdl93pggkIsRkY3MrjevmQ==\\n\"}",
+    "{\"key_id\":\"anything\",\"data\":\"SwqqSZbNtN2SOfKGtE2jfklrcARSCZE9Tdl93pggkIsRkY3MrjevmQ==\\n\"}",
+    "{\"key_id\":\"\",\"data\":\"SwqqSZbNtN2SOfKGtE2jfklrcARSCZE9Tdl93pggkIsRkY3MrjevmQ==\\n\"}"
   };
   
   //Start Message Encoder Test

--- a/test/src/util/pelz_json_parser_test_suite.c
+++ b/test/src/util/pelz_json_parser_test_suite.c
@@ -52,7 +52,6 @@ void test_encrypt_parser(void)
   const char *enc_data = "QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVoxMjM0NTY=\n";
   unsigned int enc_data_len = 45;
   const char *dec_data = "SwqqSZbNtN2SOfKGtE2jfklrcARSCZE9Tdl93pggkIsRkY3MrjevmQ==\n";
-  unsigned int dec_data_len = 57;
 
   //Building of a standard valid JSON request
   json = cJSON_CreateObject();
@@ -116,7 +115,6 @@ void test_decrypt_parser(void)
   const char *json_key_id = "file:/test/key1.txt";
   unsigned int json_key_id_len = 19;
   const char *enc_data = "QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVoxMjM0NTY=\n";
-  unsigned int enc_data_len = 45;
   const char *dec_data = "SwqqSZbNtN2SOfKGtE2jfklrcARSCZE9Tdl93pggkIsRkY3MrjevmQ==\n";
   unsigned int dec_data_len = 57;
 

--- a/test/src/util/pelz_json_parser_test_suite.c
+++ b/test/src/util/pelz_json_parser_test_suite.c
@@ -58,11 +58,8 @@ void test_encrypt_parser(void)
   json = cJSON_CreateObject();
   cJSON_AddItemToObject(json, "request_type", cJSON_CreateNumber(1));
   cJSON_AddItemToObject(json, "key_id", cJSON_CreateString(json_key_id));
-  cJSON_AddItemToObject(json, "key_id_len", cJSON_CreateNumber(json_key_id_len));
   cJSON_AddItemToObject(json, "enc_data", cJSON_CreateString(enc_data));
-  cJSON_AddItemToObject(json, "enc_data_len", cJSON_CreateNumber(enc_data_len));
   cJSON_AddItemToObject(json, "dec_data", cJSON_CreateString(dec_data));
-  cJSON_AddItemToObject(json, "dec_data_len", cJSON_CreateNumber(dec_data_len));
                        
   //Test standard valid JSON request
   CU_ASSERT(encrypt_parser(json, &key_id, &data) == 0);
@@ -89,11 +86,8 @@ void test_encrypt_parser(void)
   free_charbuf(&data);
   cJSON_AddItemToObject(json, "dec_data", cJSON_CreateString(dec_data));
 
-  cJSON_DeleteItemFromObject(json, "dec_data_len");
-  CU_ASSERT(encrypt_parser(json, &key_id, &data) == 0);
   free_charbuf(&key_id);
   free_charbuf(&data);
-  cJSON_AddItemToObject(json, "dec_data_len", cJSON_CreateNumber(dec_data_len));
 
   //Test check of JSON request isString
   cJSON_DeleteItemFromObject(json, "key_id");
@@ -192,7 +186,7 @@ void test_request_decoder(void)
   cJSON *json_dec_signed;
 
   const char *invalid_request[4] = {
-    "{\"key_id_len\": 28, \"key_id\": \"file:/test/testkeys/key2.txt\"}",
+    "{\"key_id\": \"file:/test/testkeys/key2.txt\"}",
     "{\"request_type\": \"one\"}", "{\"request_type\": 0}", "{\"request_type\": 7}"
   };
   const char *json_key_id[6] = {
@@ -266,13 +260,9 @@ void test_request_decoder(void)
   for (int i = 0; i < 6; i++)
   {
     cJSON_AddItemToObject(json_enc, "key_id", cJSON_CreateString(json_key_id[i]));
-    cJSON_AddItemToObject(json_enc, "key_id_len", cJSON_CreateNumber(json_key_id_len));
     cJSON_AddItemToObject(json_dec, "key_id", cJSON_CreateString(json_key_id[i]));
-    cJSON_AddItemToObject(json_dec, "key_id_len", cJSON_CreateNumber(json_key_id_len));
     cJSON_AddItemToObject(json_enc, "enc_data", cJSON_CreateString(enc_data[i]));
     cJSON_AddItemToObject(json_dec, "dec_data", cJSON_CreateString(dec_data[i]));
-    cJSON_AddItemToObject(json_enc, "enc_data_len", cJSON_CreateNumber(enc_data_len[i]));
-    cJSON_AddItemToObject(json_dec, "dec_data_len", cJSON_CreateNumber(dec_data_len[i]));
 
     //Creating the request charbuf for the JSON then testing request_decoder for encryption
     tmp = cJSON_PrintUnformatted(json_enc);
@@ -309,31 +299,19 @@ void test_request_decoder(void)
 
     //Free the cJSON Objects to allow the addition of the next Object per the loop
     cJSON_DeleteItemFromObject(json_dec, "dec_data");
-    cJSON_DeleteItemFromObject(json_dec, "dec_data_len");
     cJSON_DeleteItemFromObject(json_enc, "enc_data");
-    cJSON_DeleteItemFromObject(json_enc, "enc_data_len");
     cJSON_DeleteItemFromObject(json_enc, "key_id");
-    cJSON_DeleteItemFromObject(json_enc, "key_id_len");
     cJSON_DeleteItemFromObject(json_dec, "key_id");
-    cJSON_DeleteItemFromObject(json_dec, "key_id_len");
   }
     // In the future these values will have to align with the validation() function
     cJSON_AddItemToObject(json_enc_signed, "key_id", cJSON_CreateString("file:/test/key1.txt"));
-    cJSON_AddItemToObject(json_enc_signed, "key_id_len", cJSON_CreateNumber(19));
     cJSON_AddItemToObject(json_dec_signed, "key_id", cJSON_CreateString("file:/test/key1.txt"));
-    cJSON_AddItemToObject(json_dec_signed, "key_id_len", cJSON_CreateNumber(19));
     cJSON_AddItemToObject(json_enc_signed, "enc_data", cJSON_CreateString("TestData\n"));
     cJSON_AddItemToObject(json_dec_signed, "dec_data", cJSON_CreateString("TestData\n"));
-    cJSON_AddItemToObject(json_enc_signed, "enc_data_len", cJSON_CreateNumber(9));
-    cJSON_AddItemToObject(json_dec_signed, "dec_data_len", cJSON_CreateNumber(9));
     cJSON_AddItemToObject(json_enc_signed, "request_sig", cJSON_CreateString("ValueEncrypt\n"));
-    cJSON_AddItemToObject(json_enc_signed, "request_sig_len", cJSON_CreateNumber(13));
     cJSON_AddItemToObject(json_enc_signed, "requestor_cert", cJSON_CreateString("ValueEncrypt2\n"));
-    cJSON_AddItemToObject(json_enc_signed, "requestor_cert_len", cJSON_CreateNumber(14)); 
     cJSON_AddItemToObject(json_dec_signed, "request_sig", cJSON_CreateString("ValueEncrypt\n"));
-    cJSON_AddItemToObject(json_dec_signed, "request_sig_len", cJSON_CreateNumber(13));
     cJSON_AddItemToObject(json_dec_signed, "requestor_cert", cJSON_CreateString("ValueEncrypt2\n"));
-    cJSON_AddItemToObject(json_dec_signed, "requestor_cert_len", cJSON_CreateNumber(14)); 
 
     request_type = REQ_UNK;
 
@@ -373,21 +351,13 @@ void test_request_decoder(void)
     free_charbuf(&data);
 
     cJSON_DeleteItemFromObject(json_dec_signed, "dec_data");
-    cJSON_DeleteItemFromObject(json_dec_signed, "dec_data_len");
     cJSON_DeleteItemFromObject(json_enc_signed, "enc_data");
-    cJSON_DeleteItemFromObject(json_enc_signed, "enc_data_len");
     cJSON_DeleteItemFromObject(json_enc_signed, "key_id");
-    cJSON_DeleteItemFromObject(json_enc_signed, "key_id_len");
     cJSON_DeleteItemFromObject(json_dec_signed, "key_id");
-    cJSON_DeleteItemFromObject(json_dec_signed, "key_id_len");
     cJSON_DeleteItemFromObject(json_dec_signed, "request_sig");
-    cJSON_DeleteItemFromObject(json_dec_signed, "request_sig_len");
     cJSON_DeleteItemFromObject(json_dec_signed, "requestor_cert");
-    cJSON_DeleteItemFromObject(json_dec_signed, "requestor_cert_len");
     cJSON_DeleteItemFromObject(json_enc_signed, "request_sig");
-    cJSON_DeleteItemFromObject(json_enc_signed, "request_sig_len");
     cJSON_DeleteItemFromObject(json_enc_signed, "requestor_cert");
-    cJSON_DeleteItemFromObject(json_enc_signed, "requestor_cert_len");
 
   cJSON_Delete(json_enc);
   cJSON_Delete(json_dec);

--- a/test/src/util/pelz_json_parser_test_suite.c
+++ b/test/src/util/pelz_json_parser_test_suite.c
@@ -78,17 +78,9 @@ void test_encrypt_parser(void)
   CU_ASSERT(encrypt_parser(json, &key_id, &data) == 1);
   cJSON_AddItemToObject(json, "key_id", cJSON_CreateString(json_key_id));
 
-  cJSON_DeleteItemFromObject(json, "key_id_len");
-  CU_ASSERT(encrypt_parser(json, &key_id, &data) == 1);
-  cJSON_AddItemToObject(json, "key_id_len", cJSON_CreateNumber(json_key_id_len));
-
   cJSON_DeleteItemFromObject(json, "enc_data");
   CU_ASSERT(encrypt_parser(json, &key_id, &data) == 1);
   cJSON_AddItemToObject(json, "enc_data", cJSON_CreateString(enc_data));
-
-  cJSON_DeleteItemFromObject(json, "enc_data_len");
-  CU_ASSERT(encrypt_parser(json, &key_id, &data) == 1);
-  cJSON_AddItemToObject(json, "enc_data_len", cJSON_CreateNumber(enc_data_len));
 
   cJSON_DeleteItemFromObject(json, "dec_data");
   CU_ASSERT(encrypt_parser(json, &key_id, &data) == 0);
@@ -103,19 +95,6 @@ void test_encrypt_parser(void)
   free_charbuf(&data);
   cJSON_AddItemToObject(json, "dec_data_len", cJSON_CreateNumber(dec_data_len));
 
-  //Test check of JSON request isNumber
-  cJSON_DeleteItemFromObject(json, "key_id_len");
-  cJSON_AddItemToObject(json, "key_id_len", cJSON_CreateString("19"));
-  CU_ASSERT(encrypt_parser(json, &key_id, &data) == 1);
-  cJSON_DeleteItemFromObject(json, "key_id_len");
-  cJSON_AddItemToObject(json, "key_id_len", cJSON_CreateNumber(json_key_id_len));
-
-  cJSON_DeleteItemFromObject(json, "enc_data_len");
-  cJSON_AddItemToObject(json, "enc_data_len", cJSON_CreateString("45"));
-  CU_ASSERT(encrypt_parser(json, &key_id, &data) == 1);
-  cJSON_DeleteItemFromObject(json, "enc_data_len");
-  cJSON_AddItemToObject(json, "enc_data_len", cJSON_CreateNumber(enc_data_len));
-
   //Test check of JSON request isString
   cJSON_DeleteItemFromObject(json, "key_id");
   cJSON_AddItemToObject(json, "key_id", cJSON_CreateNumber(5482));
@@ -128,19 +107,6 @@ void test_encrypt_parser(void)
   CU_ASSERT(encrypt_parser(json, &key_id, &data) == 1);
   cJSON_DeleteItemFromObject(json, "enc_data");
   cJSON_AddItemToObject(json, "enc_data", cJSON_CreateString(enc_data));
-
-  //Test check of JSON request string length match
-  cJSON_DeleteItemFromObject(json, "key_id_len");
-  cJSON_AddItemToObject(json, "key_id_len", cJSON_CreateNumber(20));
-  CU_ASSERT(encrypt_parser(json, &key_id, &data) == 1);
-  cJSON_DeleteItemFromObject(json, "key_id_len");
-  cJSON_AddItemToObject(json, "key_id_len", cJSON_CreateNumber(json_key_id_len));
-
-  cJSON_DeleteItemFromObject(json, "enc_data_len");
-  cJSON_AddItemToObject(json, "enc_data_len", cJSON_CreateNumber(50));
-  CU_ASSERT(encrypt_parser(json, &key_id, &data) == 1);
-  cJSON_DeleteItemFromObject(json, "enc_data_len");
-  cJSON_AddItemToObject(json, "enc_data_len", cJSON_CreateNumber(enc_data_len));
 
   //Clean-up JSON
   cJSON_Delete(json);

--- a/test/src/util/pelz_json_parser_test_suite.c
+++ b/test/src/util/pelz_json_parser_test_suite.c
@@ -130,11 +130,8 @@ void test_decrypt_parser(void)
   json = cJSON_CreateObject();
   cJSON_AddItemToObject(json, "request_type", cJSON_CreateNumber(2));
   cJSON_AddItemToObject(json, "key_id", cJSON_CreateString(json_key_id));
-  cJSON_AddItemToObject(json, "key_id_len", cJSON_CreateNumber(json_key_id_len));
   cJSON_AddItemToObject(json, "enc_data", cJSON_CreateString(enc_data));
-  cJSON_AddItemToObject(json, "enc_data_len", cJSON_CreateNumber(enc_data_len));
   cJSON_AddItemToObject(json, "dec_data", cJSON_CreateString(dec_data));
-  cJSON_AddItemToObject(json, "dec_data_len", cJSON_CreateNumber(dec_data_len));
 
   //Test standard valid JSON request
   CU_ASSERT(decrypt_parser(json, &key_id, &data) == 0);
@@ -150,17 +147,9 @@ void test_decrypt_parser(void)
   CU_ASSERT(decrypt_parser(json, &key_id, &data) == 1);
   cJSON_AddItemToObject(json, "key_id", cJSON_CreateString(json_key_id));
 
-  cJSON_DeleteItemFromObject(json, "key_id_len");
-  CU_ASSERT(decrypt_parser(json, &key_id, &data) == 1);
-  cJSON_AddItemToObject(json, "key_id_len", cJSON_CreateNumber(json_key_id_len));
-
   cJSON_DeleteItemFromObject(json, "dec_data");
   CU_ASSERT(decrypt_parser(json, &key_id, &data) == 1);
   cJSON_AddItemToObject(json, "dec_data", cJSON_CreateString(dec_data));
-
-  cJSON_DeleteItemFromObject(json, "dec_data_len");
-  CU_ASSERT(decrypt_parser(json, &key_id, &data) == 1);
-  cJSON_AddItemToObject(json, "dec_data_len", cJSON_CreateNumber(dec_data_len));
 
   cJSON_DeleteItemFromObject(json, "enc_data");
   CU_ASSERT(decrypt_parser(json, &key_id, &data) == 0);
@@ -168,24 +157,8 @@ void test_decrypt_parser(void)
   free_charbuf(&data);
   cJSON_AddItemToObject(json, "enc_data", cJSON_CreateString(enc_data));
 
-  cJSON_DeleteItemFromObject(json, "enc_data_len");
-  CU_ASSERT(decrypt_parser(json, &key_id, &data) == 0);
   free_charbuf(&key_id);
   free_charbuf(&data);
-  cJSON_AddItemToObject(json, "enc_data_len", cJSON_CreateNumber(enc_data_len));
-
-  //Test check of JSON request isNumber
-  cJSON_DeleteItemFromObject(json, "key_id_len");
-  cJSON_AddItemToObject(json, "key_id_len", cJSON_CreateString("19"));
-  CU_ASSERT(decrypt_parser(json, &key_id, &data) == 1);
-  cJSON_DeleteItemFromObject(json, "key_id_len");
-  cJSON_AddItemToObject(json, "key_id_len", cJSON_CreateNumber(json_key_id_len));
-
-  cJSON_DeleteItemFromObject(json, "dec_data_len");
-  cJSON_AddItemToObject(json, "dec_data_len", cJSON_CreateString("57"));
-  CU_ASSERT(decrypt_parser(json, &key_id, &data) == 1);
-  cJSON_DeleteItemFromObject(json, "dec_data_len");
-  cJSON_AddItemToObject(json, "dec_data_len", cJSON_CreateNumber(dec_data_len));
 
   //Test check of JSON request isString
   cJSON_DeleteItemFromObject(json, "key_id");
@@ -199,19 +172,6 @@ void test_decrypt_parser(void)
   CU_ASSERT(decrypt_parser(json, &key_id, &data) == 1);
   cJSON_DeleteItemFromObject(json, "dec_data");
   cJSON_AddItemToObject(json, "dec_data", cJSON_CreateString(dec_data));
-
-  //Test check of JSON request string length match
-  cJSON_DeleteItemFromObject(json, "key_id_len");
-  cJSON_AddItemToObject(json, "key_id_len", cJSON_CreateNumber(20));
-  CU_ASSERT(decrypt_parser(json, &key_id, &data) == 1);
-  cJSON_DeleteItemFromObject(json, "key_id_len");
-  cJSON_AddItemToObject(json, "key_id_len", cJSON_CreateNumber(json_key_id_len));
-
-  cJSON_DeleteItemFromObject(json, "dec_data_len");
-  cJSON_AddItemToObject(json, "dec_data_len", cJSON_CreateNumber(50));
-  CU_ASSERT(decrypt_parser(json, &key_id, &data) == 1);
-  cJSON_DeleteItemFromObject(json, "dec_data_len");
-  cJSON_AddItemToObject(json, "dec_data_len", cJSON_CreateNumber(dec_data_len));
 
   //Clean-up JSON
   cJSON_Delete(json);

--- a/test/src/util/pelz_json_parser_test_suite.c
+++ b/test/src/util/pelz_json_parser_test_suite.c
@@ -15,16 +15,6 @@
 // Adds all key table tests to main test runner.
 int pelz_json_parser_suite_add_tests(CU_pSuite suite)
 {
-  
-  if (NULL == CU_add_test(suite, "Test JSON Encryption Request Parser", test_encrypt_parser))
-  {
-    return (1);
-  }
-  if (NULL == CU_add_test(suite, "Test JSON Decryption Request Parser", test_decrypt_parser))
-  {
-    return (1);
-  }
-
   if (NULL == CU_add_test(suite, "Test Decoding of JSON formatted Request", test_request_decoder))
   {
     return (1);
@@ -38,119 +28,6 @@ int pelz_json_parser_suite_add_tests(CU_pSuite suite)
     return (1);
   }
   return (0);
-}
-
-void test_encrypt_parser(void)
-{
-  cJSON *json;
-  charbuf key_id;
-  charbuf data;
-
-  //Valid Test Values
-  const char *json_key_id = "file:/test/key1.txt";
-  unsigned int json_key_id_len = 19;
-  const char *enc_data = "QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVoxMjM0NTY=\n";
-  unsigned int enc_data_len = 45;
-
-  //Building of a standard valid JSON request
-  json = cJSON_CreateObject();
-  cJSON_AddItemToObject(json, "request_type", cJSON_CreateNumber(1));
-  cJSON_AddItemToObject(json, "key_id", cJSON_CreateString(json_key_id));
-  cJSON_AddItemToObject(json, "data", cJSON_CreateString(enc_data));
-                       
-  //Test standard valid JSON request
-  CU_ASSERT(encrypt_parser(json, &key_id, &data) == 0);
-  CU_ASSERT(key_id.len == json_key_id_len);
-  CU_ASSERT(memcmp(key_id.chars, json_key_id, key_id.len) == 0);
-  CU_ASSERT(data.len == enc_data_len);
-  CU_ASSERT(memcmp(data.chars, enc_data, data.len) == 0);
-  free_charbuf(&key_id);
-  free_charbuf(&data);
-
-  //Test check of JSON request hasObject
-  cJSON_DeleteItemFromObject(json, "key_id");
-  CU_ASSERT(encrypt_parser(json, &key_id, &data) == 1);
-  cJSON_AddItemToObject(json, "key_id", cJSON_CreateString(json_key_id));
-
-  cJSON_DeleteItemFromObject(json, "data");
-  CU_ASSERT(encrypt_parser(json, &key_id, &data) == 1);
-  cJSON_AddItemToObject(json, "data", cJSON_CreateString(enc_data));
-  CU_ASSERT(encrypt_parser(json, &key_id, &data) == 0);
-
-  free_charbuf(&key_id);
-  free_charbuf(&data);
-
-  //Test check of JSON request isString
-  cJSON_DeleteItemFromObject(json, "key_id");
-  cJSON_AddItemToObject(json, "key_id", cJSON_CreateNumber(5482));
-  CU_ASSERT(encrypt_parser(json, &key_id, &data) == 1);
-  cJSON_DeleteItemFromObject(json, "key_id");
-  cJSON_AddItemToObject(json, "key_id", cJSON_CreateString(json_key_id));
-
-  cJSON_DeleteItemFromObject(json, "data");
-  cJSON_AddItemToObject(json, "data", cJSON_CreateNumber(6842));
-  CU_ASSERT(encrypt_parser(json, &key_id, &data) == 1);
-  cJSON_DeleteItemFromObject(json, "data");
-  cJSON_AddItemToObject(json, "data", cJSON_CreateString(enc_data));
-
-  //Clean-up JSON
-  cJSON_Delete(json);
-}
-
-void test_decrypt_parser(void)
-{
-  cJSON *json;
-  charbuf key_id;
-  charbuf data;
-
-  //Valid Test Values
-  const char *json_key_id = "file:/test/key1.txt";
-  unsigned int json_key_id_len = 19;
-  const char *dec_data = "SwqqSZbNtN2SOfKGtE2jfklrcARSCZE9Tdl93pggkIsRkY3MrjevmQ==\n";
-  unsigned int dec_data_len = 57;
-
-  //Building of a standard valid JSON request
-  json = cJSON_CreateObject();
-  cJSON_AddItemToObject(json, "request_type", cJSON_CreateNumber(2));
-  cJSON_AddItemToObject(json, "key_id", cJSON_CreateString(json_key_id));
-  cJSON_AddItemToObject(json, "data", cJSON_CreateString(dec_data));
-
-  //Test standard valid JSON request
-  CU_ASSERT(decrypt_parser(json, &key_id, &data) == 0);
-  CU_ASSERT(key_id.len == json_key_id_len);
-  CU_ASSERT(memcmp(key_id.chars, json_key_id, key_id.len) == 0);
-  CU_ASSERT(data.len == dec_data_len);
-  CU_ASSERT(memcmp(data.chars, dec_data, data.len) == 0);
-  free_charbuf(&key_id);
-  free_charbuf(&data);
-
-  //Test check of JSON request hasObject
-  cJSON_DeleteItemFromObject(json, "key_id");
-  CU_ASSERT(decrypt_parser(json, &key_id, &data) == 1);
-  cJSON_AddItemToObject(json, "key_id", cJSON_CreateString(json_key_id));
-
-  cJSON_DeleteItemFromObject(json, "data");
-  CU_ASSERT(decrypt_parser(json, &key_id, &data) == 1);
-  cJSON_AddItemToObject(json, "data", cJSON_CreateString(dec_data));
-
-  free_charbuf(&key_id);
-  free_charbuf(&data);
-
-  //Test check of JSON request isString
-  cJSON_DeleteItemFromObject(json, "key_id");
-  cJSON_AddItemToObject(json, "key_id", cJSON_CreateNumber(5482));
-  CU_ASSERT(decrypt_parser(json, &key_id, &data) == 1);
-  cJSON_DeleteItemFromObject(json, "key_id");
-  cJSON_AddItemToObject(json, "key_id", cJSON_CreateString(json_key_id));
-
-  cJSON_DeleteItemFromObject(json, "data");
-  cJSON_AddItemToObject(json, "data", cJSON_CreateNumber(6842));
-  CU_ASSERT(decrypt_parser(json, &key_id, &data) == 1);
-  cJSON_DeleteItemFromObject(json, "data");
-  cJSON_AddItemToObject(json, "data", cJSON_CreateString(dec_data));
-
-  //Clean-up JSON
-  cJSON_Delete(json);
 }
 
 void test_request_decoder(void)

--- a/test/src/util/pelz_json_parser_test_suite.c
+++ b/test/src/util/pelz_json_parser_test_suite.c
@@ -72,12 +72,6 @@ void test_request_decoder(void)
     57, 57, 45, 45, 33, 33
   };
 
-  /*
-  const char * request_sig_val = "Request\n";
-  unsigned int request_sig_val_len = 8;
-  const char * requestor_cert_val = "Cert1\n";
-  unsigned int requestor_cert_val_len = 6;
-  */
   pelz_log(LOG_DEBUG, "Start Request Decoder Test");
   //Test Invalid Requests with bad request_types
   for (int i = 0; i < 4; i++)
@@ -183,10 +177,6 @@ void test_request_decoder(void)
     free(tmp);
     CU_ASSERT(request_decoder(request, &request_type, &key_id, &data, &request_sig, &requestor_cert) == 0);
     CU_ASSERT(request_type == REQ_ENC_SIGNED);
-    //CU_ASSERT(key_id.len == json_key_id_len);
-    //CU_ASSERT(memcmp(key_id.chars, json_key_id, key_id.len) == 0);
-    //CU_ASSERT(data.len == enc_data_len);
-    //CU_ASSERT(memcmp(data.chars, enc_data, data.len) == 0);   
     free_charbuf(&request);
     request_type = REQ_UNK;
     free_charbuf(&key_id);
@@ -199,17 +189,13 @@ void test_request_decoder(void)
     free(tmp);
     CU_ASSERT(request_decoder(request, &request_type, &key_id, &data, &request_sig, &requestor_cert) == 0);
     CU_ASSERT(request_type == REQ_DEC_SIGNED);
-    //CU_ASSERT(key_id.len == json_key_id_len);
-    //CU_ASSERT(memcmp(key_id.chars, json_key_id, key_id.len) == 0);
-    //CU_ASSERT(data.len == enc_data_len);
-    //CU_ASSERT(memcmp(data.chars, enc_data, data.len) == 0);   
     free_charbuf(&request);
     request_type = REQ_UNK;
     free_charbuf(&key_id);
     free_charbuf(&data);
 
-    cJSON_DeleteItemFromObject(json_dec_signed, "dec_data");
-    cJSON_DeleteItemFromObject(json_enc_signed, "enc_data");
+    cJSON_DeleteItemFromObject(json_dec_signed, "data");
+    cJSON_DeleteItemFromObject(json_enc_signed, "data");
     cJSON_DeleteItemFromObject(json_enc_signed, "key_id");
     cJSON_DeleteItemFromObject(json_dec_signed, "key_id");
     cJSON_DeleteItemFromObject(json_dec_signed, "request_sig");


### PR DESCRIPTION
This pull request refactors the JSON parsing to make it much easier to add new fields. It also removes the distinction between the various data fields since only one of those should ever be present in a single request. Finally, it removes the unnecessary explicit length fields from the JSON structures since those fields all have to be ```NULL```-terminated strings.