### PR TITLE
README disclaimer updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Pelz is an open source project about managing keys within a service for other ap
 
 Pelz provides a socket interface to other programs to request AES key wrap/unwrap.  The request and response are JavaScript Object Notation (JSON) formatted. The expected JSON structure is described below. The location of key encryption keys (KEKs) is specified through a URI. The URI can identify a file, a key server destination, etc. The schemes currently implemented are specified below.
 
-Note: Pelz is currently in a prototyping phase. At this point, the application programming interface (API) is still somewhat fluid but should stabilize as fundamental capabilities mature. There are no plans for creating a release at this time. 
+Note: Pelz is a proof of concept and does not have all the security features required in a robust tool for operational use. Further, in its current prototyping phase, the application programming interface (API) is still somewhat fluid but should stabilize as fundamental capabilities mature. There are no plans for creating a release at this time.
 ----
 
 ## Running pelz as a Linux service

--- a/accumulo_plugin/README.md
+++ b/accumulo_plugin/README.md
@@ -3,11 +3,13 @@
 ## Introduction
 The pelz plug-in for Accumulo is an example of how to integrate pelz with an application handling and/or processing encrypted data (in the case of Accumulo, this application is a distributed database). 
 
+**Note: This plug-in is a proof of concept and is not intended for operational use. Further, it is not yet fully implemented.**
+
 Accumulo implements data encryption/decryption functionality via its "pluggable" [CryptoService](https://accumulo.apache.org/docs/2.x/security/on-disk-encryption) Java interface. It distributes a "default" implementation named AESCryptoService. This plug-in (PelzCryptoService) provides an alternative CryptoService implementation.
 
 Compared to the reference AESCryptoService, included with the Accumulo Crypto Module, this plug-in changes how the code handles encryption of the File Encryption Key (FEK) by using pelz for the AES Key Wrap. PelzCryptoService employs pelz key wrapping/unwrapping services in place of a standard cryptographic library. Most importantly, this pelz-based approach constrains both the Key Encryption Keys (KEKs), used to wrap/unwrap FEKs, and the unwrapped FEKs, used to encrypt/decrypt data, within the pelz trusted execution environment (TEE).
 
-The current differences between PelzCryptoService and the AESCryptoService can be summarized as: 
+The differences between PelzCryptoService and the AESCryptoService can be summarized as: 
 
 1. PelzCryptoService adds socket creation and management features.
 2. PelzCryptoService adds socket message creation and handling functionality. 


### PR DESCRIPTION
Expanded/changed the wording of the bolded "note" in the main pelz README.md, and added a "not intended for operational use" bolded "note" to the pelz Accumulo plug-in README.md.