### PR TITLE
Signed request validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,7 @@ App_Pipe_File := src/pelz/main.c
 
 App_Cpp_Files := src/util/charbuf.c \
 		 src/util/pelz_json_parser.c \
+		 src/util/request_signing.c \
 		 src/util/pelz_service.c \
 		 src/util/pelz_socket.c \
 		 src/util/fifo_thread.c \

--- a/Makefile
+++ b/Makefile
@@ -313,6 +313,10 @@ endif
 
 ######## Common Objects ########
 
+sgx/ec_key_cert_marshal.o: kmyth/sgx/common/src/ec_key_cert_marshal.c
+	@$(CC) $(App_C_Flags) -c $< -o $@
+	@echo "CC   <=  $<"
+
 sgx/ec_key_cert_unmarshal.o: kmyth/sgx/common/src/ec_key_cert_unmarshal.c
 	@$(CC) $(App_C_Flags) -c $< -o $@
 	@echo "CC   <=  $<"
@@ -368,6 +372,7 @@ test/bin/$(App_Name_Test): $(App_Cpp_Test_Files) \
 				 src/util/cmd_interface.c \
 			   $(App_Cpp_Kmyth_Files) \
 				 sgx/test_enclave_u.o \
+				 sgx/ec_key_cert_marshal.o \
 				 sgx/ec_key_cert_unmarshal.o \
 				 sgx/log_ocall.o \
 				 sgx/ecdh_ocall.o \
@@ -378,6 +383,7 @@ test/bin/$(App_Name_Test): $(App_Cpp_Test_Files) \
 			 -Isgx \
 			 -Itest/include \
 			 $(App_C_Flags) \
+			 -g \
 			 $(ENCLAVE_HEADERS) \
 			 $(App_Link_Flags) \
 			 -lcrypto \
@@ -609,9 +615,11 @@ test: all test-all
 	@openssl x509 -in test/data/node_pub.pem -inform pem -out test/data/node_pub.der -outform der
 	@openssl x509 -in test/data/proxy_pub.pem -inform pem -out test/data/proxy_pub.der -outform der
 	@openssl pkey -in test/data/node_priv.pem -inform pem -out test/data/node_priv.der -outform der
+	@openssl x509 -in test/data/test-ca.pem -inform pem -out test/data/test-ca.der -outform der
 	@./bin/pelz seal test/data/node_pub.der -o test/data/node_pub.der.nkl
 	@./bin/pelz seal test/data/proxy_pub.der -o test/data/proxy_pub.der.nkl
 	@./bin/pelz seal test/data/node_priv.der -o test/data/node_priv.der.nkl
+	@./bin/pelz seal test/data/test-ca.der -o test/data/test-ca.der.nkl
 	@echo "GEN => Test Key/Cert Files"
 	@cd kmyth/sgx && make demo-pre demo/bin/ecdh-server --eval="Demo_App_C_Flags += -DDEMO_LOG_LEVEL=LOG_WARNING"
 	@./kmyth/sgx/demo/bin/ecdh-server -r test/data/proxy_priv.pem -u test/data/node_pub.pem -p 7000 -m 1 2> /dev/null &

--- a/Makefile
+++ b/Makefile
@@ -107,6 +107,7 @@ App_Cpp_Test_Files := test/src/pelz_test.c \
 		 test/src/util/util_test_suite.c \
 		 test/src/util/aes_keywrap_test_suite.c \
 		 test/src/util/pelz_json_parser_test_suite.c \
+		 test/src/util/request_signing_test_suite.c \
 		 test/src/util/test_helper_functions.c \
 		 test/src/util/test_pelz_uri_helpers.c \
 		 test/src/util/table_test_suite.c \

--- a/Makefile
+++ b/Makefile
@@ -117,6 +117,7 @@ App_Cpp_Test_Files := test/src/pelz_test.c \
 App_Cpp_Files_for_Test := src/util/common_table.c \
 		 src/util/key_table.c \
 		 src/util/server_table.c \
+		 src/util/ca_table.c \
 		 src/util/aes_keywrap_3394nopad.c \
 		 src/util/pelz_request_handler.c
 
@@ -502,6 +503,10 @@ sgx/server_table.o: src/util/server_table.c
 	@$(CC) $(Enclave_C_Flags) $(ENCLAVE_HEADERS) -c $< -o $@
 	@echo "CC  <=  $<"
 
+sgx/ca_table.o: src/util/ca_table.c
+	@$(CC) $(Enclave_C_Flags) $(ENCLAVE_HEADERS) -c $< -o $@
+	@echo "CC  <=  $<"
+
 sgx/channel_table.o: src/util/channel_table.c
 	@$(CC) $(Enclave_C_Flags) $(ENCLAVE_HEADERS) -c $< -o $@
 	@echo "CC  <=  $<"
@@ -522,6 +527,7 @@ sgx/$(Enclave_Name): sgx/pelz_enclave_t.o \
 		     sgx/common_table.o \
 		     sgx/key_table.o \
 		     sgx/server_table.o \
+		     sgx/ca_table.o \
 				 sgx/channel_table.o \
 		     sgx/aes_keywrap_3394nopad.o \
 		     sgx/pelz_request_handler.o \
@@ -557,6 +563,7 @@ sgx/$(Test_Enclave_Name): sgx/test_enclave_t.o \
 						sgx/common_table.o \
      			  sgx/key_table.o \
      			  sgx/server_table.o \
+     			  sgx/ca_table.o \
 						sgx/channel_table.o \
      			  sgx/aes_keywrap_3394nopad.o \
      			  sgx/pelz_request_handler.o \

--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ JSON Request for AES Key Unwrap
 * {"key_id": "file:~/pelz/test/key1.txt", "request_type": 2, "data": "BtIjIgvCaVBwUi5jTOZyIx2yJamqvrR0BZWLFVufz9w=\n"}
 * {"key_id": "pelz://localhost/7000/fake_key_id", "request_type": 2, "data": "BtIjIgvCaVBwUi5jTOZyIx2yJamqvrR0BZWLFVufz9w=\n"}
 
+##### Signed Request JSON
+
+
 #### Response JSON Key and Values
 * key_id : string of characters
     * URI for the key location (key identifier).

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ The JSON objects can be in two forms: requests and responses.
     * 3 for AES Key Wrap (signed JSON request) - still being implemented
     * 4 for AES Key Unwrap (signed JSON request) - still being implemented
 * key_id : string of characters
-     * URI for the key location - used as the key identifier.
-     * URI syntax must currently comply with RFC 8089 and RFC 1738 Section 3.1.
+    * URI for the key location - used as the key identifier.
+    * URI syntax must currently comply with RFC 8089 and RFC 1738 Section 3.1.
 * data : string of characters
     * Base64 encoded data to be processed based on request type.
 
@@ -53,6 +53,15 @@ JSON Request for AES Key Unwrap
 
 ##### Signed Request JSON
 
+In addition to the fields from unsigned requests,
+described above, signed requests include:
+
+* requestor_cert : string of characters
+    * X509 certificate in PEM format.
+    * The certificate must be signed by a certificate authority that is trusted by Pelz.
+* request_sig : string of characters
+    * Base64 encoded digital signature of the message content.
+    * The signing key must correspond to the public key in the requestor_cert.
 
 #### Response JSON Key and Values
 * key_id : string of characters

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ In addition to the fields from unsigned requests,
 described above, signed requests include:
 
 * requestor_cert : string of characters
-    * X509 certificate in PEM format.
+    * X509 certificate in base64 encoded DER format.
     * The certificate must be signed by a certificate authority that is trusted by Pelz.
 * request_sig : string of characters
     * Base64 encoded digital signature of the message content.

--- a/include/pelz_json_parser.h
+++ b/include/pelz_json_parser.h
@@ -114,20 +114,4 @@ int decrypt_parser(cJSON * json, charbuf * key_id, charbuf * data);
  */
 int signed_parser(cJSON * json, charbuf * request_sig, charbuf * requestor_cert);
 
-/**
- * <pre>
- * Validation function. The validation process will determine if the supplied signature and certificate match
- * <pre>
- *
- * @param[in] json Parsed json string in cJSON format to be copied into request values
- *
- * @param[out] data.chars The data to be encrypted
- * @param[out] request_sig.chars The supplied signature
- * @param[out] requestor_cert.len The supplied user certificate
- *
- * @return 0 on success, 1 on error
- *
- */
-int validate_signature(RequestType * request_type, charbuf * key_id, charbuf * data, charbuf * request_sig, charbuf * requestor_cert);
-
 #endif /* INCLUDE_JSON_PARSER_H_ */

--- a/include/request_signing.h
+++ b/include/request_signing.h
@@ -1,0 +1,27 @@
+/*
+ * request_signing.h
+ */
+
+#ifndef INCLUDE_REQUEST_SIGNING_H_
+#define INCLUDE_REQUEST_SIGNING_H_
+
+#include <charbuf.h>
+#include <pelz_request_handler.h>
+
+/**
+ * <pre>
+ * Validation function. The validation process will determine if the supplied signature and certificate match
+ * <pre>
+ *
+ * @param[in] json Parsed json string in cJSON format to be copied into request values
+ *
+ * @param[out] data.chars The data to be encrypted
+ * @param[out] request_sig.chars The supplied signature
+ * @param[out] requestor_cert.len The supplied user certificate
+ *
+ * @return 0 on success, 1 on error
+ *
+ */
+int validate_signature(RequestType * request_type, charbuf * key_id, charbuf * data, charbuf * request_sig, charbuf * requestor_cert);
+
+#endif /* INCLUDE_REQUEST_SIGNING_H_ */

--- a/include/request_signing.h
+++ b/include/request_signing.h
@@ -5,6 +5,8 @@
 #ifndef INCLUDE_REQUEST_SIGNING_H_
 #define INCLUDE_REQUEST_SIGNING_H_
 
+#include <openssl/evp.h>
+
 #include <charbuf.h>
 #include <pelz_request_handler.h>
 
@@ -23,5 +25,22 @@
  *
  */
 int validate_signature(RequestType * request_type, charbuf * key_id, charbuf * data, charbuf * request_sig, charbuf * requestor_cert);
+
+/**
+ * <pre>
+ * Generate the signature for a signed pelz request.
+ * This is intended for demonstration/testing purposes only because it runs outside the enclave.
+ * <pre>
+ *
+ * @param[in] sign_pkey The requestor's private key.
+ * @param[in] request_type The request type value.
+ * @param[in] key_id The request key ID.
+ * @param[in] key_id The request data to be wrapped/unwrapped.
+ * @param[in] requestor_cert The requestor's X509 certificate.
+ *
+ * @return A charbuf containing the signature, or an empty charbuf on failure.
+ *
+ */
+charbuf create_signature(EVP_PKEY * sign_pkey, RequestType * request_type, charbuf * key_id, charbuf * data, charbuf * requestor_cert);
 
 #endif /* INCLUDE_REQUEST_SIGNING_H_ */

--- a/include/request_signing.h
+++ b/include/request_signing.h
@@ -12,14 +12,14 @@
 
 /**
  * <pre>
- * Validation function. The validation process will determine if the supplied signature and certificate match
+ * Validate the signature and certificate for a Pelz request.
  * <pre>
  *
- * @param[in] json Parsed json string in cJSON format to be copied into request values
- *
- * @param[out] data.chars The data to be encrypted
- * @param[out] request_sig.chars The supplied signature
- * @param[out] requestor_cert.len The supplied user certificate
+ * @param[in] request_type The request type value.
+ * @param[in] key_id The request key ID.
+ * @param[in] data The request data to be wrapped/unwrapped (base64 encoded).
+ * @param[in] request_sig The digital signature for the request content (base64 encoded).
+ * @param[in] requestor_cert The requestor's X509 certificate (base64 encoded DER).
  *
  * @return 0 on success, 1 on error
  *
@@ -28,21 +28,34 @@ int validate_signature(RequestType * request_type, charbuf * key_id, charbuf * d
 
 /**
  * <pre>
- * Generate the signature for a signed pelz request.
+ * Generate the signature for a signed Pelz request.
  * This is intended for demonstration/testing purposes only because it runs outside the enclave.
  * <pre>
  *
  * @param[in] sign_pkey The requestor's private key.
  * @param[in] request_type The request type value.
  * @param[in] key_id The request key ID.
- * @param[in] key_id The request data to be wrapped/unwrapped.
- * @param[in] requestor_cert The requestor's X509 certificate.
+ * @param[in] data The request data to be wrapped/unwrapped (base64 encoded).
+ * @param[in] requestor_cert The requestor's X509 certificate (base64 encoded DER).
  *
  * @return A charbuf containing the signature, or an empty charbuf on failure.
  *
  */
 charbuf create_signature(EVP_PKEY * sign_pkey, RequestType * request_type, charbuf * key_id, charbuf * data, charbuf * requestor_cert);
 
+/**
+ * <pre>
+ * Serialize the contents of a signed Pelz request.
+ * <pre>
+ *
+ * @param[in] request_type The request type value.
+ * @param[in] key_id The request key ID.
+ * @param[in] data The request data to be wrapped/unwrapped (base64 encoded).
+ * @param[in] requestor_cert The requestor's X509 certificate (base64 encoded DER).
+ *
+ * @return A charbuf containing the serialization, or an empty charbuf on failure.
+ *
+ */
 charbuf serialize_request_data(RequestType * request_type, charbuf * key_id, charbuf * data, charbuf * requestor_cert);
 
 #endif /* INCLUDE_REQUEST_SIGNING_H_ */

--- a/include/request_signing.h
+++ b/include/request_signing.h
@@ -43,4 +43,6 @@ int validate_signature(RequestType * request_type, charbuf * key_id, charbuf * d
  */
 charbuf create_signature(EVP_PKEY * sign_pkey, RequestType * request_type, charbuf * key_id, charbuf * data, charbuf * requestor_cert);
 
+charbuf serialize_request_data(RequestType * request_type, charbuf * key_id, charbuf * data, charbuf * requestor_cert);
+
 #endif /* INCLUDE_REQUEST_SIGNING_H_ */

--- a/sgx/pelz_enclave.edl
+++ b/sgx/pelz_enclave.edl
@@ -80,6 +80,18 @@ public TableResponseStatus add_cert_to_table(TableType type, uint64_t handle);
 
 /**
  * <pre>
+ * Verify a certificate using the trusted CA certs in the CA table.
+ * </pre>
+ *
+ * @param[in] target The certificate to be verified, as a DER charbuf.
+ *
+ * @return OK on success, an error message indicating the type of
+ *                    error otherwise.
+ */
+public TableResponseStatus verify_cert(charbuf target_der);
+
+/**
+ * <pre>
  * This function initializes a pkey.
  * <pre>
  *

--- a/src/util/ca_table.c
+++ b/src/util/ca_table.c
@@ -1,0 +1,82 @@
+/*
+ * ca_table.c
+ */
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <openssl/x509.h>
+#include <openssl/x509_vfy.h>
+#include <openssl/x509v3.h>
+
+#include <common_table.h>
+#include <charbuf.h>
+#include <pelz_enclave_log.h>
+
+#include "sgx_trts.h"
+#include ENCLAVE_HEADER_TRUSTED
+#include "kmyth_enclave_trusted.h"
+
+
+TableResponseStatus verify_cert(charbuf target_der)
+{
+  Table *table = get_table_by_type(CA_TABLE);
+  if (table == NULL)
+  {
+    kmyth_sgx_log(LOG_ERR, "get_table_by_type failed");
+    return ERR;
+  }
+
+  X509 *target = d2i_X509(NULL, (const unsigned char **) &target_der.chars, target_der.len);
+  if (target == NULL)
+  {
+    kmyth_sgx_log(LOG_ERR, "DER to X509 format conversion failed");
+    return ERR;
+  }
+
+  // OpenSSL_add_all_algorithms();
+
+  // Create cert store
+  X509_STORE *store = X509_STORE_new();
+  if (store == NULL)
+  {
+    kmyth_sgx_log(LOG_ERR, "X509_STORE_new failed");
+    return ERR;
+  }
+
+  // Put all ca certs in the store
+  for (unsigned int i = 0; i < table->num_entries; i++)
+  {
+    X509 *cert = table->entries[i].value.cert;
+    if (X509_STORE_add_cert(store, cert) != 1)
+    {
+      kmyth_sgx_log(LOG_ERR, "X509_STORE_add_cert failed");
+      return ERR;
+    }
+  }
+
+  // Create store context
+  X509_STORE_CTX *store_ctx = X509_STORE_CTX_new();
+  if (store_ctx == NULL)
+  {
+    kmyth_sgx_log(LOG_ERR, "X509_STORE_CTX_new failed");
+    return ERR;
+  }
+
+  if (X509_STORE_CTX_init(store_ctx, store, target, NULL) != 1)
+  {
+    kmyth_sgx_log(LOG_ERR, "X509_STORE_CTX_init failed");
+    return ERR;
+  }
+
+  // X509_STORE_CTX_set_purpose(x509_store_ctx, X509_PURPOSE_ANY);
+  
+  int success = X509_verify_cert(store_ctx);
+
+  X509_STORE_CTX_free(store_ctx);
+  X509_STORE_free(store);
+  X509_free(target);
+
+  return (success == 1) ? OK : NO_MATCH;
+}

--- a/src/util/ca_table.c
+++ b/src/util/ca_table.c
@@ -71,7 +71,7 @@ TableResponseStatus verify_cert(charbuf target_der)
   }
 
   // X509_STORE_CTX_set_purpose(x509_store_ctx, X509_PURPOSE_ANY);
-  
+
   int success = X509_verify_cert(store_ctx);
 
   X509_STORE_CTX_free(store_ctx);

--- a/src/util/ca_table.c
+++ b/src/util/ca_table.c
@@ -35,8 +35,6 @@ TableResponseStatus verify_cert(charbuf target_der)
     return ERR;
   }
 
-  // OpenSSL_add_all_algorithms();
-
   // Create cert store
   X509_STORE *store = X509_STORE_new();
   if (store == NULL)
@@ -69,8 +67,6 @@ TableResponseStatus verify_cert(charbuf target_der)
     kmyth_sgx_log(LOG_ERR, "X509_STORE_CTX_init failed");
     return ERR;
   }
-
-  // X509_STORE_CTX_set_purpose(x509_store_ctx, X509_PURPOSE_ANY);
 
   int success = X509_verify_cert(store_ctx);
 

--- a/src/util/pelz_json_parser.c
+++ b/src/util/pelz_json_parser.c
@@ -132,18 +132,24 @@ int request_decoder(charbuf request, RequestType * request_type, charbuf * key_i
       free_charbuf(requestor_cert);
       return 1;
     }
+
+    if ( validate_signature(request_type, key_id, data, request_sig, requestor_cert) )
+    {
+      pelz_log(LOG_ERR, "Signature Validation Error");
+      cJSON_Delete(json);
+      free_charbuf(key_id);
+      free_charbuf(data);
+      free_charbuf(request_sig);
+      free_charbuf(requestor_cert);
+      return (1);
+    }
   }
-  
-  if ( validate_signature(request_type, key_id, data, request_sig, requestor_cert) )
+  else
   {
-    pelz_log(LOG_ERR, "Signature Validation Error");
-    cJSON_Delete(json);
-    free_charbuf(key_id);
-    free_charbuf(data);
-    free_charbuf(request_sig);
-    free_charbuf(requestor_cert);
-    return (1);
+    *request_sig = new_charbuf(0);
+    *requestor_cert = new_charbuf(0);
   }
+
   cJSON_Delete(json);
   return (0);
 }

--- a/src/util/pelz_json_parser.c
+++ b/src/util/pelz_json_parser.c
@@ -7,6 +7,7 @@
 #include <stdlib.h>
 #include <cjson/cJSON.h>
 
+
 #include <pelz_json_parser.h>
 #include <pelz_request_handler.h>
 #include <charbuf.h>

--- a/src/util/pelz_json_parser.c
+++ b/src/util/pelz_json_parser.c
@@ -2,16 +2,21 @@
  * json_parser.c
  */
 
+#include <stdint.h>
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
+#include <arpa/inet.h>
 #include <cjson/cJSON.h>
 
+#include <openssl/x509.h>
 
 #include <pelz_json_parser.h>
 #include <pelz_request_handler.h>
 #include <charbuf.h>
 #include <pelz_log.h>
+
+#include "ecdh_util.h"
 
 /**
  * <pre>
@@ -218,48 +223,158 @@ int message_encoder(RequestType request_type, charbuf key_id, charbuf data, char
   return (0);
 }
 
-// At some point this function will have to contain a concatenated string of the buffer fields to ensure order when comparing info
+// TODO: Consider moving these functions to a separate source file
+
+/* Concatenate request data for signing and validation. */
+charbuf serialize_request_data(RequestType * request_type, charbuf * key_id, charbuf * data, charbuf * requestor_cert)
+{
+  // Note: It may be possible to have collisions with this serialization because some field lengths are not fixed.
+
+  uint16_t req_type = *request_type;
+  size_t concat_len = sizeof(req_type) + key_id->len + requestor_cert->len + data->len;
+  size_t place = 0;
+  charbuf serial = new_charbuf(concat_len);
+
+  if (serial.chars == NULL)
+  {
+    return serial;
+  }
+
+  req_type = htons(req_type);
+
+  memcpy(serial.chars + place, &req_type, sizeof(req_type));
+  place += sizeof(req_type);
+  memcpy(serial.chars + place, key_id->chars, key_id->len);
+  place += key_id->len;
+  memcpy(serial.chars + place, requestor_cert->chars, requestor_cert->len);
+  place += requestor_cert->len;
+  memcpy(serial.chars + place, data->chars, data->len);
+  place += data->len;
+
+  return serial;
+}
+
+charbuf create_signature(EVP_PKEY * sign_pkey, RequestType * request_type, charbuf * key_id, charbuf * data, charbuf * requestor_cert)
+{
+  // Note: This is included for demonstration/testing purposes.
+  // A production implementation should run within SGX for data protection.
+
+  int ret;
+  charbuf signature = new_charbuf(0);
+  unsigned char *sig_buff = NULL;
+  unsigned int sig_len = 0;
+  charbuf serial = serialize_request_data(request_type, key_id, data, requestor_cert);
+
+  if (serial.chars == NULL)
+  {
+    return signature;
+  }
+
+  ret = sign_buffer(sign_pkey, serial.chars, serial.len, &sig_buff, &sig_len);
+
+  free_charbuf(&serial);
+
+  if (ret != EXIT_SUCCESS)
+  {
+    pelz_log(LOG_ERR, "sign_buffer failed");
+    return signature;
+  }
+
+  signature = new_charbuf(sig_len);
+  memcpy(signature.chars, sig_buff, sig_len);
+
+  return signature;
+}
+
+X509 * load_cert(charbuf * requestor_cert)
+{
+  // create BIO wrapper for cert string
+  BIO *cert_bio = BIO_new_mem_buf(requestor_cert->chars, requestor_cert->len);
+  if (cert_bio == NULL)
+  {
+    pelz_log(LOG_ERR, "BIO creation failed");
+    return NULL;
+  }
+
+  // load requestor's X509 certificate from BIO
+  X509 *cert_x509 = PEM_read_bio_X509(cert_bio, NULL, 0, NULL);
+
+  BIO_free(cert_bio);
+  cert_bio = NULL;
+
+  if (cert_x509 == NULL)
+  {
+    pelz_log(LOG_ERR, "Requestor cert could not be read as PEM X509 format.");
+    return NULL;
+  }
+
+  return cert_x509;
+}
+
+/* Check if the request cert is signed by a known CA. */
+int check_cert_chain(X509 *requestor_x509) {
+  // FIXME: not yet implemented
+
+  // requires ecall to access stored CA certs
+
+  return 0;
+}
+
+
 int validate_signature(RequestType * request_type, charbuf * key_id, charbuf * data, charbuf * request_sig, charbuf * requestor_cert)
 {
-  int a = key_id->len;
-  int b = data->len;
+  // Note: This is vulnerable to signature replay attacks.
 
-  int length = 9 + key_id->len + data->len;
-
-  // Offset for memcpy()
-  int offset = 0;
-
-  unsigned char my_buffer[length+1];
-
-  // Request Type data
-  char request_buffer[2];
-  sprintf(request_buffer, "%d", *((int*)request_type));
-  
-  // Key_id length data
-  char key_buffer[4];
-  sprintf(key_buffer, "%d", a);
-
-  // 'Data' length data
-  char data_buffer[4];
-  sprintf(data_buffer, "%d", b);
- 
-  // 'Concatenating' all of our data
-  memcpy(my_buffer + offset, request_buffer, 1);
-  offset += 1;
-  memcpy(my_buffer + offset, key_id->chars, key_id->len);
-  offset += key_id->len;
-  memcpy(my_buffer + offset, data->chars, data->len);
-  offset += data->len;
-  memcpy(my_buffer + offset, key_buffer, 4);
-  offset += 4;
-  memcpy(my_buffer + offset, data_buffer, 4);
+  int ret;
+  X509 *requestor_x509;
+  EVP_PKEY *requestor_pubkey;
+  charbuf serial;
 
   // Extract the public key from requestor_cert
+  requestor_x509 = load_cert(requestor_cert);
+  if (requestor_x509 == NULL)
+  {
+    pelz_log(LOG_ERR, "load_cert failed");
+    return 1;
+  }
 
-  // verify_buffer() function, similar logic to sign_buffer()
+  requestor_pubkey = X509_get_pubkey(requestor_x509);
+  if (requestor_pubkey == NULL)
+  {
+    pelz_log(LOG_ERR, "X509_get_pubkey failed");
+    X509_free(requestor_x509);
+    return 1;
+  }
 
-  // At this point, we pass control to a certificate validating function inside the enclave
+  serial = serialize_request_data(request_type, key_id, data, requestor_cert);
+  if (serial.chars == NULL)
+  {
+    X509_free(requestor_x509);
+    EVP_PKEY_free(requestor_pubkey);
+    return 1;
+  }
 
-  // Stub
+  /* Check that the request signature matches the request data. */
+  ret = verify_buffer(requestor_pubkey, serial.chars, serial.len, request_sig->chars, request_sig->len);
+
+  free_charbuf(&serial);
+  EVP_PKEY_free(requestor_pubkey);
+
+  if (ret)
+  {
+    X509_free(requestor_x509);
+    return 1;
+  }
+
+  ret = check_cert_chain(requestor_x509);
+  if (ret)
+  {
+    X509_free(requestor_x509);
+    return 1;
+  }
+
+  X509_free(requestor_x509);
+  requestor_x509 = NULL;
+
   return 0;
 }

--- a/src/util/pelz_json_parser.c
+++ b/src/util/pelz_json_parser.c
@@ -220,24 +220,10 @@ int message_encoder(RequestType request_type, charbuf key_id, charbuf data, char
 // At some point this function will have to contain a concatenated string of the buffer fields to ensure order when comparing info
 int validate_signature(RequestType * request_type, charbuf * key_id, charbuf * data, charbuf * request_sig, charbuf * requestor_cert)
 {
-  // How we get the lengths of the fields to allocate buffer space
-  int count_a = 0;
-  int a = key_id->len; 
-  do{ 
-    a = a / 10; 
-    ++count_a; 
-  }while (a != 0) ;
-  a = key_id->len;
-  int count_b = 0;
-  int b = data->len; 
-  do{ 
-    b = b / 10; 
-    ++count_b; 
-  }while (b != 0) ;
-  b = data->len;
+  int a = key_id->len;
+  int b = data->len;
 
-  // Length: request_type + key_id->len length + data->len length + key_id length + data length
-  int length = 1 + key_id->len + data->len + count_a + count_b;
+  int length = 9 + key_id->len + data->len;
 
   // Offset for memcpy()
   int offset = 0;
@@ -249,11 +235,11 @@ int validate_signature(RequestType * request_type, charbuf * key_id, charbuf * d
   sprintf(request_buffer, "%d", *((int*)request_type));
   
   // Key_id length data
-  char key_buffer[count_a];
+  char key_buffer[4];
   sprintf(key_buffer, "%d", a);
 
   // 'Data' length data
-  char data_buffer[count_b];
+  char data_buffer[4];
   sprintf(data_buffer, "%d", b);
  
   // 'Concatenating' all of our data
@@ -261,16 +247,11 @@ int validate_signature(RequestType * request_type, charbuf * key_id, charbuf * d
   offset += 1;
   memcpy(my_buffer + offset, key_id->chars, key_id->len);
   offset += key_id->len;
-  memcpy(my_buffer + offset, key_buffer, count_a);
-  offset += count_a;
-  memcpy(my_buffer + offset, data_buffer, count_b);
-  offset += count_b;
   memcpy(my_buffer + offset, data->chars, data->len);
   offset += data->len;
-  
-  // Add null terminator to the end of the array
-  my_buffer[length-1] = '\0';
-  //printf("%s\n", my_buffer);
+  memcpy(my_buffer + offset, key_buffer, 4);
+  offset += 4;
+  memcpy(my_buffer + offset, data_buffer, 4);
 
   // Extract the public key from requestor_cert
 

--- a/src/util/pelz_json_parser.c
+++ b/src/util/pelz_json_parser.c
@@ -112,6 +112,10 @@ int request_decoder(charbuf request, RequestType * request_type, charbuf * key_i
 
   if(*request_type == REQ_ENC_SIGNED || *request_type == REQ_DEC_SIGNED)
   {
+    // TODO: Remove this once signed requests are supported.
+    pelz_log(LOG_ERR, "Signed requests are not fully implemented.");
+    return 1;
+
     *request_sig = get_JSON_string_field(json, "request_sig");
     if(request_sig->len == 0 || request_sig->chars == NULL)
     {

--- a/src/util/pelz_json_parser.c
+++ b/src/util/pelz_json_parser.c
@@ -2,21 +2,16 @@
  * json_parser.c
  */
 
-#include <stdint.h>
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
-#include <arpa/inet.h>
 #include <cjson/cJSON.h>
-
-#include <openssl/x509.h>
 
 #include <pelz_json_parser.h>
 #include <pelz_request_handler.h>
 #include <charbuf.h>
 #include <pelz_log.h>
-
-#include "ecdh_util.h"
+#include <request_signing.h>
 
 /**
  * <pre>
@@ -221,160 +216,4 @@ int message_encoder(RequestType request_type, charbuf key_id, charbuf data, char
   cJSON_Delete(root);
   free(tmp);
   return (0);
-}
-
-// TODO: Consider moving these functions to a separate source file
-
-/* Concatenate request data for signing and validation. */
-charbuf serialize_request_data(RequestType * request_type, charbuf * key_id, charbuf * data, charbuf * requestor_cert)
-{
-  // Note: It may be possible to have collisions with this serialization because some field lengths are not fixed.
-
-  uint16_t req_type = *request_type;
-  size_t concat_len = sizeof(req_type) + key_id->len + requestor_cert->len + data->len;
-  size_t place = 0;
-  charbuf serial = new_charbuf(concat_len);
-
-  if (serial.chars == NULL)
-  {
-    return serial;
-  }
-
-  req_type = htons(req_type);
-
-  memcpy(serial.chars + place, &req_type, sizeof(req_type));
-  place += sizeof(req_type);
-  memcpy(serial.chars + place, key_id->chars, key_id->len);
-  place += key_id->len;
-  memcpy(serial.chars + place, requestor_cert->chars, requestor_cert->len);
-  place += requestor_cert->len;
-  memcpy(serial.chars + place, data->chars, data->len);
-  place += data->len;
-
-  return serial;
-}
-
-charbuf create_signature(EVP_PKEY * sign_pkey, RequestType * request_type, charbuf * key_id, charbuf * data, charbuf * requestor_cert)
-{
-  // Note: This is included for demonstration/testing purposes.
-  // A production implementation should run within SGX for data protection.
-
-  int ret;
-  charbuf signature = new_charbuf(0);
-  unsigned char *sig_buff = NULL;
-  unsigned int sig_len = 0;
-  charbuf serial = serialize_request_data(request_type, key_id, data, requestor_cert);
-
-  if (serial.chars == NULL)
-  {
-    return signature;
-  }
-
-  ret = sign_buffer(sign_pkey, serial.chars, serial.len, &sig_buff, &sig_len);
-
-  free_charbuf(&serial);
-
-  if (ret != EXIT_SUCCESS)
-  {
-    pelz_log(LOG_ERR, "sign_buffer failed");
-    return signature;
-  }
-
-  signature = new_charbuf(sig_len);
-  memcpy(signature.chars, sig_buff, sig_len);
-
-  return signature;
-}
-
-X509 * load_cert(charbuf * requestor_cert)
-{
-  // create BIO wrapper for cert string
-  BIO *cert_bio = BIO_new_mem_buf(requestor_cert->chars, requestor_cert->len);
-  if (cert_bio == NULL)
-  {
-    pelz_log(LOG_ERR, "BIO creation failed");
-    return NULL;
-  }
-
-  // load requestor's X509 certificate from BIO
-  X509 *cert_x509 = PEM_read_bio_X509(cert_bio, NULL, 0, NULL);
-
-  BIO_free(cert_bio);
-  cert_bio = NULL;
-
-  if (cert_x509 == NULL)
-  {
-    pelz_log(LOG_ERR, "Requestor cert could not be read as PEM X509 format.");
-    return NULL;
-  }
-
-  return cert_x509;
-}
-
-/* Check if the request cert is signed by a known CA. */
-int check_cert_chain(X509 *requestor_x509) {
-  // FIXME: not yet implemented
-
-  // requires ecall to access stored CA certs
-
-  return 0;
-}
-
-
-int validate_signature(RequestType * request_type, charbuf * key_id, charbuf * data, charbuf * request_sig, charbuf * requestor_cert)
-{
-  // Note: This is vulnerable to signature replay attacks.
-
-  int ret;
-  X509 *requestor_x509;
-  EVP_PKEY *requestor_pubkey;
-  charbuf serial;
-
-  // Extract the public key from requestor_cert
-  requestor_x509 = load_cert(requestor_cert);
-  if (requestor_x509 == NULL)
-  {
-    pelz_log(LOG_ERR, "load_cert failed");
-    return 1;
-  }
-
-  requestor_pubkey = X509_get_pubkey(requestor_x509);
-  if (requestor_pubkey == NULL)
-  {
-    pelz_log(LOG_ERR, "X509_get_pubkey failed");
-    X509_free(requestor_x509);
-    return 1;
-  }
-
-  serial = serialize_request_data(request_type, key_id, data, requestor_cert);
-  if (serial.chars == NULL)
-  {
-    X509_free(requestor_x509);
-    EVP_PKEY_free(requestor_pubkey);
-    return 1;
-  }
-
-  /* Check that the request signature matches the request data. */
-  ret = verify_buffer(requestor_pubkey, serial.chars, serial.len, request_sig->chars, request_sig->len);
-
-  free_charbuf(&serial);
-  EVP_PKEY_free(requestor_pubkey);
-
-  if (ret)
-  {
-    X509_free(requestor_x509);
-    return 1;
-  }
-
-  ret = check_cert_chain(requestor_x509);
-  if (ret)
-  {
-    X509_free(requestor_x509);
-    return 1;
-  }
-
-  X509_free(requestor_x509);
-  requestor_x509 = NULL;
-
-  return 0;
 }

--- a/src/util/pelz_json_parser.c
+++ b/src/util/pelz_json_parser.c
@@ -220,6 +220,27 @@ int message_encoder(RequestType request_type, charbuf key_id, charbuf data, char
 // At some point this function will have to contain a concatenated string of the buffer fields to ensure order when comparing info
 int validate_signature(RequestType * request_type, charbuf * key_id, charbuf * data, charbuf * request_sig, charbuf * requestor_cert)
 {
+
+  char my_buffer[1+key_id->len+data->len];
+  char a[key_id->len];
+  char b[data->len];
+  sprintf(a, "%zu", key_id->len);
+  sprintf(b, "%zu", data->len);
+  sprintf(my_buffer, "%d", *((int*)request_type));
+  strcat(my_buffer, (char*) key_id->chars);
+  strcat(my_buffer, a);
+  strcat(my_buffer, (char*) data->chars);
+  strcat(my_buffer, b);
+
+  // Extract the public key from requestor_cert
+
+  // sign_buffer() w/ my_buffer, request_sig, and respective lengths
+    // If failure, log error like the functions above, and return
+
+  // verify_buffer() function, similar logic to sign_buffer()
+
+  // At this point, we pass control to a certificate validating function inside the enclave
+
   // Stub
   return 0;
 }

--- a/src/util/request_signing.c
+++ b/src/util/request_signing.c
@@ -1,0 +1,170 @@
+/*
+ * request_signing.c
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <arpa/inet.h>
+
+#include <openssl/x509.h>
+
+#include <pelz_log.h>
+#include <request_signing.h>
+
+#include "ecdh_util.h"
+
+/* Concatenate request data for signing and validation. */
+charbuf serialize_request_data(RequestType * request_type, charbuf * key_id, charbuf * data, charbuf * requestor_cert)
+{
+  // Note: It may be possible to have collisions with this serialization because some field lengths are not fixed.
+
+  uint16_t req_type = *request_type;
+  size_t concat_len = sizeof(req_type) + key_id->len + requestor_cert->len + data->len;
+  size_t place = 0;
+  charbuf serial = new_charbuf(concat_len);
+
+  if (serial.chars == NULL)
+  {
+    return serial;
+  }
+
+  req_type = htons(req_type);
+
+  memcpy(serial.chars + place, &req_type, sizeof(req_type));
+  place += sizeof(req_type);
+  memcpy(serial.chars + place, key_id->chars, key_id->len);
+  place += key_id->len;
+  memcpy(serial.chars + place, requestor_cert->chars, requestor_cert->len);
+  place += requestor_cert->len;
+  memcpy(serial.chars + place, data->chars, data->len);
+  place += data->len;
+
+  return serial;
+}
+
+charbuf create_signature(EVP_PKEY * sign_pkey, RequestType * request_type, charbuf * key_id, charbuf * data, charbuf * requestor_cert)
+{
+  // Note: This is included for demonstration/testing purposes.
+  // A production implementation should run within SGX for data protection.
+
+  int ret;
+  charbuf signature = new_charbuf(0);
+  unsigned char *sig_buff = NULL;
+  unsigned int sig_len = 0;
+  charbuf serial = serialize_request_data(request_type, key_id, data, requestor_cert);
+
+  if (serial.chars == NULL)
+  {
+    return signature;
+  }
+
+  ret = sign_buffer(sign_pkey, serial.chars, serial.len, &sig_buff, &sig_len);
+
+  free_charbuf(&serial);
+
+  if (ret != EXIT_SUCCESS)
+  {
+    pelz_log(LOG_ERR, "sign_buffer failed");
+    return signature;
+  }
+
+  signature = new_charbuf(sig_len);
+  memcpy(signature.chars, sig_buff, sig_len);
+
+  return signature;
+}
+
+X509 * load_cert(charbuf * requestor_cert)
+{
+  // create BIO wrapper for cert string
+  BIO *cert_bio = BIO_new_mem_buf(requestor_cert->chars, requestor_cert->len);
+  if (cert_bio == NULL)
+  {
+    pelz_log(LOG_ERR, "BIO creation failed");
+    return NULL;
+  }
+
+  // load requestor's X509 certificate from BIO
+  X509 *cert_x509 = PEM_read_bio_X509(cert_bio, NULL, 0, NULL);
+
+  BIO_free(cert_bio);
+  cert_bio = NULL;
+
+  if (cert_x509 == NULL)
+  {
+    pelz_log(LOG_ERR, "Requestor cert could not be read as PEM X509 format.");
+    return NULL;
+  }
+
+  return cert_x509;
+}
+
+/* Check if the request cert is signed by a known CA. */
+int check_cert_chain(X509 *requestor_x509) {
+  // FIXME: not yet implemented
+
+  // requires ecall to access stored CA certs
+
+  return 0;
+}
+
+
+int validate_signature(RequestType * request_type, charbuf * key_id, charbuf * data, charbuf * request_sig, charbuf * requestor_cert)
+{
+  // Note: This is vulnerable to signature replay attacks.
+
+  int ret;
+  X509 *requestor_x509;
+  EVP_PKEY *requestor_pubkey;
+  charbuf serial;
+
+  // Extract the public key from requestor_cert
+  requestor_x509 = load_cert(requestor_cert);
+  if (requestor_x509 == NULL)
+  {
+    pelz_log(LOG_ERR, "load_cert failed");
+    return 1;
+  }
+
+  requestor_pubkey = X509_get_pubkey(requestor_x509);
+  if (requestor_pubkey == NULL)
+  {
+    pelz_log(LOG_ERR, "X509_get_pubkey failed");
+    X509_free(requestor_x509);
+    return 1;
+  }
+
+  serial = serialize_request_data(request_type, key_id, data, requestor_cert);
+  if (serial.chars == NULL)
+  {
+    X509_free(requestor_x509);
+    EVP_PKEY_free(requestor_pubkey);
+    return 1;
+  }
+
+  /* Check that the request signature matches the request data. */
+  ret = verify_buffer(requestor_pubkey, serial.chars, serial.len, request_sig->chars, request_sig->len);
+
+  free_charbuf(&serial);
+  EVP_PKEY_free(requestor_pubkey);
+
+  if (ret)
+  {
+    X509_free(requestor_x509);
+    return 1;
+  }
+
+  ret = check_cert_chain(requestor_x509);
+  if (ret)
+  {
+    X509_free(requestor_x509);
+    return 1;
+  }
+
+  X509_free(requestor_x509);
+  requestor_x509 = NULL;
+
+  return 0;
+}

--- a/src/util/request_signing.c
+++ b/src/util/request_signing.c
@@ -47,7 +47,7 @@ charbuf serialize_request_data(RequestType * request_type, charbuf * key_id, cha
 charbuf create_signature(EVP_PKEY * sign_pkey, RequestType * request_type, charbuf * key_id, charbuf * data, charbuf * requestor_cert)
 {
   // Note: This is included for demonstration/testing purposes.
-  // A production implementation should run within SGX for data protection.
+  // A production implementation should run within the enclave for data protection.
 
   int ret;
   charbuf signature = new_charbuf(0);
@@ -109,7 +109,6 @@ int check_cert_chain(X509 *requestor_x509) {
 
   return 0;
 }
-
 
 int validate_signature(RequestType * request_type, charbuf * key_id, charbuf * data, charbuf * request_sig, charbuf * requestor_cert)
 {

--- a/src/util/request_signing.c
+++ b/src/util/request_signing.c
@@ -126,17 +126,19 @@ int validate_signature(RequestType * request_type, charbuf * key_id, charbuf * d
   X509 *requestor_x509;
   EVP_PKEY *requestor_pubkey;
   charbuf serial;
+  const unsigned char *der_buf;
 
   // Undo base64 encoding
   ret = decodeBase64Data(encoded_cert->chars, encoded_cert->len, &decoded_cert.chars, &decoded_cert.len);
   if (ret != 0)
   {
     pelz_log(LOG_ERR, "decodeBase64Data failed");
-    free_charbuf(&decoded_sig);
     return 1;
   }
 
-  requestor_x509 = d2i_X509(NULL, (const unsigned char **) &decoded_cert.chars, decoded_cert.len);
+  // Load DER cert (requires temporary pointer)
+  der_buf = decoded_cert.chars;
+  requestor_x509 = d2i_X509(NULL, &der_buf, decoded_cert.len);
   if (requestor_x509 == NULL)
   {
     kmyth_sgx_log(LOG_ERR, "DER to X509 format conversion failed");

--- a/src/util/request_signing.c
+++ b/src/util/request_signing.c
@@ -10,7 +10,7 @@
 
 #include <openssl/x509.h>
 
-#include "kmyth/formatting_tools.h"
+#include <kmyth/formatting_tools.h>
 
 #include <pelz_log.h>
 #include <request_signing.h>
@@ -90,7 +90,7 @@ charbuf create_signature(EVP_PKEY * sign_pkey, RequestType * request_type, charb
   return signature;
 }
 
-X509 * load_cert(charbuf * requestor_cert)
+X509 * load_pem_cert(charbuf * requestor_cert)
 {
   // create BIO wrapper for cert string
   BIO *cert_bio = BIO_new_mem_buf(requestor_cert->chars, requestor_cert->len);
@@ -115,43 +115,59 @@ X509 * load_cert(charbuf * requestor_cert)
   return cert_x509;
 }
 
-int validate_signature(RequestType * request_type, charbuf * key_id, charbuf * data, charbuf * encoded_sig, charbuf * requestor_cert)
+int validate_signature(RequestType * request_type, charbuf * key_id, charbuf * data, charbuf * encoded_sig, charbuf * encoded_cert)
 {
   // Note: This is vulnerable to signature replay attacks.
 
   int ret;
   charbuf decoded_sig = new_charbuf(0);
+  charbuf decoded_cert = new_charbuf(0);
   X509 *requestor_x509;
   EVP_PKEY *requestor_pubkey;
   charbuf serial;
+
+  // Undo base64 encoding
+  ret = decodeBase64Data(encoded_cert->chars, encoded_cert->len, &decoded_cert.chars, &decoded_cert.len);
+  if (ret != 0)
+  {
+    pelz_log(LOG_ERR, "decodeBase64Data failed");
+    free_charbuf(&decoded_sig);
+    return 1;
+  }
+
+  requestor_x509 = d2i_X509(NULL, (const unsigned char **) &decoded_cert.chars, decoded_cert.len);
+  if (requestor_x509 == NULL)
+  {
+    kmyth_sgx_log(LOG_ERR, "DER to X509 format conversion failed");
+    free_charbuf(&decoded_cert);
+    return 1;
+  }
+
+  // Extract the public key from requestor_cert
+  requestor_pubkey = X509_get_pubkey(requestor_x509);
+  if (requestor_pubkey == NULL)
+  {
+    pelz_log(LOG_ERR, "X509_get_pubkey failed");
+    free_charbuf(&decoded_cert);
+    X509_free(requestor_x509);
+    return 1;
+  }
+
+  serial = serialize_request_data(request_type, key_id, data, encoded_cert);
+  if (serial.chars == NULL)
+  {
+    free_charbuf(&decoded_cert);
+    X509_free(requestor_x509);
+    EVP_PKEY_free(requestor_pubkey);
+    return 1;
+  }
 
   // Undo base64 encoding
   ret = decodeBase64Data(encoded_sig->chars, encoded_sig->len, &decoded_sig.chars, &decoded_sig.len);
   if (ret != 0)
   {
     pelz_log(LOG_ERR, "decodeBase64Data failed");
-    return 1;
-  }
-
-  // Extract the public key from requestor_cert
-  requestor_x509 = load_cert(requestor_cert);
-  if (requestor_x509 == NULL)
-  {
-    pelz_log(LOG_ERR, "load_cert failed");
-    return 1;
-  }
-
-  requestor_pubkey = X509_get_pubkey(requestor_x509);
-  if (requestor_pubkey == NULL)
-  {
-    pelz_log(LOG_ERR, "X509_get_pubkey failed");
-    X509_free(requestor_x509);
-    return 1;
-  }
-
-  serial = serialize_request_data(request_type, key_id, data, requestor_cert);
-  if (serial.chars == NULL)
-  {
+    free_charbuf(&decoded_cert);
     X509_free(requestor_x509);
     EVP_PKEY_free(requestor_pubkey);
     return 1;
@@ -161,25 +177,27 @@ int validate_signature(RequestType * request_type, charbuf * key_id, charbuf * d
   ret = verify_buffer(requestor_pubkey, serial.chars, serial.len, decoded_sig.chars, decoded_sig.len);
 
   free_charbuf(&serial);
+  free_charbuf(&decoded_sig);
   EVP_PKEY_free(requestor_pubkey);
 
   if (ret)
   {
+    free_charbuf(&decoded_cert);
     X509_free(requestor_x509);
     return 1;
   }
 
   /* Check if the request cert is signed by a known CA. */
   TableResponseStatus status;
-  verify_cert(eid, &status, *requestor_cert);
+  verify_cert(eid, &status, decoded_cert);
+
+  free_charbuf(&decoded_cert);
+  X509_free(requestor_x509);
+
   if (status != OK)
   {
-    X509_free(requestor_x509);
     return 1;
   }
-
-  X509_free(requestor_x509);
-  requestor_x509 = NULL;
 
   return 0;
 }

--- a/src/util/request_signing.c
+++ b/src/util/request_signing.c
@@ -117,7 +117,8 @@ X509 * load_pem_cert(charbuf * requestor_cert)
 
 int validate_signature(RequestType * request_type, charbuf * key_id, charbuf * data, charbuf * encoded_sig, charbuf * encoded_cert)
 {
-  // Note: This is vulnerable to signature replay attacks.
+  // Note: This is vulnerable to signature replay attacks,
+  //       but we will use message encryption to avoid leaking sensitive data.
 
   int ret;
   charbuf decoded_sig = new_charbuf(0);

--- a/test/data/gen_test_keys_certs.bash
+++ b/test/data/gen_test_keys_certs.bash
@@ -1,6 +1,15 @@
+# Generate key+cert for local ECDH application
 openssl ecparam -name secp384r1 -genkey -noout -out node_priv.pem
 openssl req -new -x509 -key node_priv.pem -subj "/CN=TestClient" -out node_pub.pem -days 365
 
+# Generate key+cert for remote ECDH service
 openssl ecparam -name secp384r1 -genkey -noout -out proxy_priv.pem
 openssl req -new -x509 -key proxy_priv.pem -subj "/CN=localhost" -out proxy_pub.pem -days 365
 
+# Generate CA key+cert
+openssl req -new -x509 -nodes -subj "/CN=PelzTest-CA" -keyout test-ca.key -out test-ca.pem -days 365
+
+# Generate key+csr+cert for remote client, signed by the CA
+openssl ecparam -name secp384r1 -genkey -noout -out worker_priv.pem
+openssl req -new -sha512 -key worker_priv.pem -subj "/CN=TestWorker" -out worker_pub.csr
+openssl x509 -req -sha256 -in worker_pub.csr -out worker_pub.pem -CAcreateserial -CAkey test-ca.key -CA test-ca.pem -days 365

--- a/test/include/pelz_json_parser_test_suite.h
+++ b/test/include/pelz_json_parser_test_suite.h
@@ -16,6 +16,7 @@ int pelz_json_parser_suite_add_tests(CU_pSuite suite);
 void test_encrypt_parser(void);
 void test_decrypt_parser(void);
 void test_request_decoder(void);
+void test_signed_request_decoder(void);
 void test_message_encoder(void);
 void test_error_message_encoder(void);
 

--- a/test/include/request_signing_test_suite.h
+++ b/test/include/request_signing_test_suite.h
@@ -16,5 +16,6 @@ void test_create_validate_signature_simple(void);
 void test_create_validate_signature(void);
 void test_verify_cert_chain(void);
 void test_verify_cert_chain_enclave(void);
+void test_invalid_cert_chain_enclave(void);
 
 #endif /* PELZ_REQUEST_SIGNING_SUITE_H_ */

--- a/test/include/request_signing_test_suite.h
+++ b/test/include/request_signing_test_suite.h
@@ -9,9 +9,12 @@
 #include <CUnit/CUnit.h>
 
 // Adds all tests to suite in main test runner
-int pelz_request_signing_suite_add_tests(CU_pSuite suite);
+int request_signing_suite_add_tests(CU_pSuite suite);
 
 // Tests
+void test_create_validate_signature_simple(void);
 void test_create_validate_signature(void);
+void test_verify_cert_chain(void);
+void test_verify_cert_chain_enclave(void);
 
 #endif /* PELZ_REQUEST_SIGNING_SUITE_H_ */

--- a/test/include/request_signing_test_suite.h
+++ b/test/include/request_signing_test_suite.h
@@ -1,0 +1,17 @@
+/*
+ * request_signing_test_suite.h
+ */
+
+#ifndef PELZ_REQUEST_SIGNING_SUITE_H_
+#define PELZ_REQUEST_SIGNING_SUITE_H_
+
+#include "request_signing.h"
+#include <CUnit/CUnit.h>
+
+// Adds all tests to suite in main test runner
+int pelz_request_signing_suite_add_tests(CU_pSuite suite);
+
+// Tests
+void test_create_validate_signature(void);
+
+#endif /* PELZ_REQUEST_SIGNING_SUITE_H_ */

--- a/test/src/pelz_test.c
+++ b/test/src/pelz_test.c
@@ -12,6 +12,7 @@
 #include "util_test_suite.h"
 #include "aes_keywrap_test_suite.h"
 #include "pelz_json_parser_test_suite.h"
+#include "request_signing_test_suite.h"
 #include "table_test_suite.h"
 #include "request_test_suite.h"
 #include "cmd_interface_test_suite.h"
@@ -129,6 +130,21 @@ int main(int argc, char **argv)
     return CU_get_error();
   }
   if (pelz_json_parser_suite_add_tests(pelz_json_parser_Suite))
+  {
+    CU_cleanup_registry();
+    return CU_get_error();
+  }
+
+  // Add request signing test suite ---- tests request signing/validation operations
+  CU_pSuite request_signing_Suite = NULL;
+
+  request_signing_Suite = CU_add_suite("Pelz Request Signing Suite", init_suite, clean_suite);
+  if (NULL == request_signing_Suite)
+  {
+    CU_cleanup_registry();
+    return CU_get_error();
+  }
+  if (request_signing_suite_add_tests(request_signing_Suite))
   {
     CU_cleanup_registry();
     return CU_get_error();

--- a/test/src/util/pelz_json_parser_test_suite.c
+++ b/test/src/util/pelz_json_parser_test_suite.c
@@ -19,11 +19,10 @@ int pelz_json_parser_suite_add_tests(CU_pSuite suite)
   {
     return (1);
   }
-  // TODO: Enable this once signed requests are supported.
-  // if (NULL == CU_add_test(suite, "Test Decoding of JSON formatted signed Request", test_signed_request_decoder))
-  // {
-  //   return (1);
-  // }
+  if (NULL == CU_add_test(suite, "Test Decoding of JSON formatted signed Request", test_signed_request_decoder))
+  {
+    return (1);
+  }
   if (NULL == CU_add_test(suite, "Test Encoding of JSON formatted Response Message", test_message_encoder))
   {
     return (1);
@@ -191,7 +190,7 @@ void test_signed_request_decoder(void)
   request = new_charbuf(strlen(tmp));
   memcpy(request.chars, tmp, request.len);
   free(tmp);
-  CU_ASSERT(request_decoder(request, &request_type, &key_id, &data, &request_sig, &requestor_cert) == 0);
+  CU_ASSERT(request_decoder(request, &request_type, &key_id, &data, &request_sig, &requestor_cert) == 1);  // temporary return value
   CU_ASSERT(request_type == REQ_ENC_SIGNED);
   free_charbuf(&request);
   request_type = REQ_UNK;
@@ -203,7 +202,7 @@ void test_signed_request_decoder(void)
   request = new_charbuf(strlen(tmp));
   memcpy(request.chars, tmp, request.len);
   free(tmp);
-  CU_ASSERT(request_decoder(request, &request_type, &key_id, &data, &request_sig, &requestor_cert) == 0);
+  CU_ASSERT(request_decoder(request, &request_type, &key_id, &data, &request_sig, &requestor_cert) == 1);  // temporary return value
   CU_ASSERT(request_type == REQ_DEC_SIGNED);
   free_charbuf(&request);
   request_type = REQ_UNK;

--- a/test/src/util/pelz_json_parser_test_suite.c
+++ b/test/src/util/pelz_json_parser_test_suite.c
@@ -19,6 +19,10 @@ int pelz_json_parser_suite_add_tests(CU_pSuite suite)
   {
     return (1);
   }
+  if (NULL == CU_add_test(suite, "Test Decoding of JSON formatted signed Request", test_signed_request_decoder))
+  {
+    return (1);
+  }
   if (NULL == CU_add_test(suite, "Test Encoding of JSON formatted Response Message", test_message_encoder))
   {
     return (1);
@@ -41,8 +45,6 @@ void test_request_decoder(void)
   charbuf requestor_cert;
   cJSON *json_enc;
   cJSON *json_dec;
-  cJSON *json_enc_signed;
-  cJSON *json_dec_signed;
 
   const char *invalid_request[4] = {
     "{\"key_id\": \"file:/test/testkeys/key2.txt\"}",
@@ -82,17 +84,12 @@ void test_request_decoder(void)
     free_charbuf(&request);
     request_type = REQ_UNK;
   }
-  
+
   //Building of the json request and most combinations
   json_enc = cJSON_CreateObject();
   json_dec = cJSON_CreateObject();
-  json_enc_signed = cJSON_CreateObject();
-  json_dec_signed = cJSON_CreateObject();
-  cJSON_AddItemToObject(json_enc, "request_type", cJSON_CreateNumber(1));
-  cJSON_AddItemToObject(json_dec, "request_type", cJSON_CreateNumber(2));
-  cJSON_AddItemToObject(json_enc_signed, "request_type", cJSON_CreateNumber(3));
-  cJSON_AddItemToObject(json_dec_signed, "request_type", cJSON_CreateNumber(4));
-
+  cJSON_AddItemToObject(json_enc, "request_type", cJSON_CreateNumber(REQ_ENC));
+  cJSON_AddItemToObject(json_dec, "request_type", cJSON_CreateNumber(REQ_DEC));
 
   tmp = cJSON_PrintUnformatted(json_enc);
   request = new_charbuf(strlen(tmp));
@@ -101,7 +98,7 @@ void test_request_decoder(void)
   CU_ASSERT(request_decoder(request, &request_type, &key_id, &data, &request_sig, &requestor_cert) == 1);
   free_charbuf(&request);
   request_type = REQ_UNK;
-  
+
   tmp = cJSON_PrintUnformatted(json_dec);
   request = new_charbuf(strlen(tmp));
   memcpy(request.chars, tmp, request.len);
@@ -109,7 +106,7 @@ void test_request_decoder(void)
   CU_ASSERT(request_decoder(request, &request_type, &key_id, &data, &request_sig, &requestor_cert) == 1);
   free_charbuf(&request);
   request_type = REQ_UNK;
-  
+
   for (int i = 0; i < 6; i++)
   {
     cJSON_AddItemToObject(json_enc, "key_id", cJSON_CreateString(json_key_id[i]));
@@ -126,13 +123,12 @@ void test_request_decoder(void)
     CU_ASSERT(key_id.len == json_key_id_len);
     CU_ASSERT(memcmp(key_id.chars, json_key_id[i], key_id.len) == 0);
     CU_ASSERT(data.len == enc_data_len[i]);
-    CU_ASSERT(memcmp(data.chars, enc_data[i], data.len) == 0);   
+    CU_ASSERT(memcmp(data.chars, enc_data[i], data.len) == 0);
     free_charbuf(&request);
     request_type = REQ_UNK;
     free_charbuf(&key_id);
     free_charbuf(&data);
 
-    
     //Creating the request charbuf for the JSON then testing request_decoder for decryption
     tmp = cJSON_PrintUnformatted(json_dec);
     request = new_charbuf(strlen(tmp));
@@ -155,56 +151,75 @@ void test_request_decoder(void)
     cJSON_DeleteItemFromObject(json_enc, "key_id");
     cJSON_DeleteItemFromObject(json_dec, "key_id");
   }
-    // In the future these values will have to align with the validation() function
-    cJSON_AddItemToObject(json_enc_signed, "key_id", cJSON_CreateString("file:/test/key1.txt"));
-    cJSON_AddItemToObject(json_dec_signed, "key_id", cJSON_CreateString("file:/test/key1.txt"));
-    cJSON_AddItemToObject(json_enc_signed, "data", cJSON_CreateString("TestData\n"));
-    cJSON_AddItemToObject(json_dec_signed, "data", cJSON_CreateString("TestData\n"));
-    cJSON_AddItemToObject(json_enc_signed, "request_sig", cJSON_CreateString("ValueEncrypt\n"));
-    cJSON_AddItemToObject(json_enc_signed, "requestor_cert", cJSON_CreateString("ValueEncrypt2\n"));
-    cJSON_AddItemToObject(json_dec_signed, "request_sig", cJSON_CreateString("ValueEncrypt\n"));
-    cJSON_AddItemToObject(json_dec_signed, "requestor_cert", cJSON_CreateString("ValueEncrypt2\n"));
-
-    request_type = REQ_UNK;
-
-    // The memory and length comparisons don't seem to be working, similar to when we last worked on these test cases
-    // We'll have to fix that in the near future
-
-    //Creating the request charbuf for the JSON then testing request signed encoder for encryption
-    tmp = cJSON_PrintUnformatted(json_enc_signed);
-    request = new_charbuf(strlen(tmp));
-    memcpy(request.chars, tmp, request.len);
-    free(tmp);
-    CU_ASSERT(request_decoder(request, &request_type, &key_id, &data, &request_sig, &requestor_cert) == 0);
-    CU_ASSERT(request_type == REQ_ENC_SIGNED);
-    free_charbuf(&request);
-    request_type = REQ_UNK;
-    free_charbuf(&key_id);
-    free_charbuf(&data);
-    
-    //Creating the request charbuf for the JSON then testing request signed decoder for encryption
-    tmp = cJSON_PrintUnformatted(json_dec_signed);
-    request = new_charbuf(strlen(tmp));
-    memcpy(request.chars, tmp, request.len);
-    free(tmp);
-    CU_ASSERT(request_decoder(request, &request_type, &key_id, &data, &request_sig, &requestor_cert) == 0);
-    CU_ASSERT(request_type == REQ_DEC_SIGNED);
-    free_charbuf(&request);
-    request_type = REQ_UNK;
-    free_charbuf(&key_id);
-    free_charbuf(&data);
-
-    cJSON_DeleteItemFromObject(json_dec_signed, "data");
-    cJSON_DeleteItemFromObject(json_enc_signed, "data");
-    cJSON_DeleteItemFromObject(json_enc_signed, "key_id");
-    cJSON_DeleteItemFromObject(json_dec_signed, "key_id");
-    cJSON_DeleteItemFromObject(json_dec_signed, "request_sig");
-    cJSON_DeleteItemFromObject(json_dec_signed, "requestor_cert");
-    cJSON_DeleteItemFromObject(json_enc_signed, "request_sig");
-    cJSON_DeleteItemFromObject(json_enc_signed, "requestor_cert");
 
   cJSON_Delete(json_enc);
   cJSON_Delete(json_dec);
+}
+
+void test_signed_request_decoder(void)
+{
+  charbuf request;
+  char *tmp;
+  RequestType request_type;
+  charbuf key_id;
+  charbuf data;
+  charbuf request_sig;
+  charbuf requestor_cert;
+  cJSON *json_enc_signed;
+  cJSON *json_dec_signed;
+
+  json_enc_signed = cJSON_CreateObject();
+  json_dec_signed = cJSON_CreateObject();
+  cJSON_AddItemToObject(json_enc_signed, "request_type", cJSON_CreateNumber(REQ_ENC_SIGNED));
+  cJSON_AddItemToObject(json_dec_signed, "request_type", cJSON_CreateNumber(REQ_DEC_SIGNED));
+
+  // In the future these values will have to align with the validation() function
+  cJSON_AddItemToObject(json_enc_signed, "key_id", cJSON_CreateString("file:/test/key1.txt"));
+  cJSON_AddItemToObject(json_dec_signed, "key_id", cJSON_CreateString("file:/test/key1.txt"));
+  cJSON_AddItemToObject(json_enc_signed, "data", cJSON_CreateString("TestData\n"));
+  cJSON_AddItemToObject(json_dec_signed, "data", cJSON_CreateString("TestData\n"));
+  cJSON_AddItemToObject(json_enc_signed, "request_sig", cJSON_CreateString("ValueEncrypt\n"));
+  cJSON_AddItemToObject(json_enc_signed, "requestor_cert", cJSON_CreateString("ValueEncrypt2\n"));
+  cJSON_AddItemToObject(json_dec_signed, "request_sig", cJSON_CreateString("ValueEncrypt\n"));
+  cJSON_AddItemToObject(json_dec_signed, "requestor_cert", cJSON_CreateString("ValueEncrypt2\n"));
+
+  request_type = REQ_UNK;
+
+  //Creating the request charbuf for the JSON then testing request signed encoder for encryption
+  tmp = cJSON_PrintUnformatted(json_enc_signed);
+  request = new_charbuf(strlen(tmp));
+  memcpy(request.chars, tmp, request.len);
+  free(tmp);
+  CU_ASSERT(request_decoder(request, &request_type, &key_id, &data, &request_sig, &requestor_cert) == 0);
+  CU_ASSERT(request_type == REQ_ENC_SIGNED);
+  free_charbuf(&request);
+  request_type = REQ_UNK;
+  free_charbuf(&key_id);
+  free_charbuf(&data);
+
+  //Creating the request charbuf for the JSON then testing request signed decoder for encryption
+  tmp = cJSON_PrintUnformatted(json_dec_signed);
+  request = new_charbuf(strlen(tmp));
+  memcpy(request.chars, tmp, request.len);
+  free(tmp);
+  CU_ASSERT(request_decoder(request, &request_type, &key_id, &data, &request_sig, &requestor_cert) == 0);
+  CU_ASSERT(request_type == REQ_DEC_SIGNED);
+  free_charbuf(&request);
+  request_type = REQ_UNK;
+  free_charbuf(&key_id);
+  free_charbuf(&data);
+
+  cJSON_DeleteItemFromObject(json_dec_signed, "data");
+  cJSON_DeleteItemFromObject(json_enc_signed, "data");
+  cJSON_DeleteItemFromObject(json_enc_signed, "key_id");
+  cJSON_DeleteItemFromObject(json_dec_signed, "key_id");
+  cJSON_DeleteItemFromObject(json_dec_signed, "request_sig");
+  cJSON_DeleteItemFromObject(json_dec_signed, "requestor_cert");
+  cJSON_DeleteItemFromObject(json_enc_signed, "request_sig");
+  cJSON_DeleteItemFromObject(json_enc_signed, "requestor_cert");
+
+  cJSON_Delete(json_enc_signed);
+  cJSON_Delete(json_dec_signed);
 }
 
 void test_message_encoder(void)
@@ -229,7 +244,7 @@ void test_message_encoder(void)
     "{\"key_id\":\"anything\",\"data\":\"SwqqSZbNtN2SOfKGtE2jfklrcARSCZE9Tdl93pggkIsRkY3MrjevmQ==\\n\"}",
     "{\"key_id\":\"\",\"data\":\"SwqqSZbNtN2SOfKGtE2jfklrcARSCZE9Tdl93pggkIsRkY3MrjevmQ==\\n\"}"
   };
-  
+
   //Start Message Encoder Test
   pelz_log(LOG_DEBUG, "Start Message Encoder Test");
 
@@ -238,25 +253,11 @@ void test_message_encoder(void)
   key_id = new_charbuf(strlen(test[0]));
   memcpy(key_id.chars, test[0], key_id.len);
 
-  request_sig = new_charbuf(11);
-  memcpy(request_sig.chars, "HelloWorld\n", request_sig.len);
-  requestor_cert = new_charbuf(11);
-  memcpy(requestor_cert.chars, "PelzProject\n", requestor_cert.len);
-
   // Testing unknown request
   CU_ASSERT(message_encoder(REQ_UNK, key_id, data, &message) == 1);
-
-  // Testing a request without signatures/certificates (This will be removed after they are required)
-  free_charbuf(&request_sig);
-  free_charbuf(&requestor_cert);
-  CU_ASSERT(message_encoder(REQ_ENC, key_id, data, &message) == 0);
   free_charbuf(&key_id);
-  // Restore values
-  request_sig = new_charbuf(11);
-  memcpy(request_sig.chars, "HelloWorld\n", request_sig.len);
-  requestor_cert = new_charbuf(11);
-  memcpy(requestor_cert.chars, "PelzProject\n", requestor_cert.len);
 
+  // Testing unsigned responses
   for (int i = 0; i < 5; i++)
   {
     key_id = new_charbuf(strlen(test[i]));
@@ -269,6 +270,15 @@ void test_message_encoder(void)
     free_charbuf(&message);
     free_charbuf(&key_id);
   }
+
+  // TODO: Test signed responses
+  request_sig = new_charbuf(11);
+  memcpy(request_sig.chars, "HelloWorld\n", request_sig.len);
+  requestor_cert = new_charbuf(11);
+  memcpy(requestor_cert.chars, "PelzProject\n", requestor_cert.len);
+  free_charbuf(&request_sig);
+  free_charbuf(&requestor_cert);
+
   free_charbuf(&data);
 }
 

--- a/test/src/util/pelz_json_parser_test_suite.c
+++ b/test/src/util/pelz_json_parser_test_suite.c
@@ -19,10 +19,11 @@ int pelz_json_parser_suite_add_tests(CU_pSuite suite)
   {
     return (1);
   }
-  if (NULL == CU_add_test(suite, "Test Decoding of JSON formatted signed Request", test_signed_request_decoder))
-  {
-    return (1);
-  }
+  // TODO: Enable this once signed requests are supported.
+  // if (NULL == CU_add_test(suite, "Test Decoding of JSON formatted signed Request", test_signed_request_decoder))
+  // {
+  //   return (1);
+  // }
   if (NULL == CU_add_test(suite, "Test Encoding of JSON formatted Response Message", test_message_encoder))
   {
     return (1);

--- a/test/src/util/request_signing_test_suite.c
+++ b/test/src/util/request_signing_test_suite.c
@@ -1,0 +1,85 @@
+/*
+ * request_signing_test_suite.c
+ */
+
+#include "request_signing_test_suite.h"
+
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <openssl/x509.h>
+#include <openssl/pem.h>
+
+
+#include <charbuf.h>
+#include <pelz_log.h>
+
+
+#define TEST_KEY_ID "file:/fake/path/to/key.txt"
+#define TEST_DATA "0123456789abcdef"
+
+
+int request_signing_test_suite_add_tests(CU_pSuite suite)
+{
+  if (NULL == CU_add_test(suite, "Test Signature Creation and Validation", test_create_validate_signature))
+  {
+    return (1);
+  }
+  return (0);
+}
+
+/* Read remote certificate (X509) and private key from PEM files. */
+void load_test_key_pair(X509 **requestor_cert, EVP_PKEY **requestor_privkey)
+{
+  BIO *cert_bio = BIO_new_file("test/data/node_pub.pem", "r");
+  BIO *key_bio = BIO_new_file("test/data/node_priv.pem", "r");
+
+  *requestor_cert = PEM_read_bio_X509(cert_bio, NULL, 0, NULL);
+  BIO_free(cert_bio);
+
+  *requestor_privkey = PEM_read_bio_PrivateKey(key_bio, NULL, 0, NULL);
+  BIO_free(key_bio);
+}
+
+void test_create_validate_signature(void)
+{
+  int ret;
+  X509 *requestor_cert;
+  EVP_PKEY *requestor_privkey;
+  BIO *pem_bio;
+  BUF_MEM *pem_buf;
+  RequestType req_type = REQ_ENC;
+  charbuf key_id, data, requestor_cert_pem, signature;
+
+  // initialize request data
+  key_id = new_charbuf(strlen(TEST_KEY_ID));
+  memcpy(key_id.chars, TEST_KEY_ID, key_id.len);
+
+  data = new_charbuf(strlen(TEST_DATA));
+  memcpy(key_id.chars, TEST_DATA, key_id.len);
+
+  // load key pair from file
+  load_test_key_pair(&requestor_cert, &requestor_privkey);
+
+  // convert x509 to pem string
+  pem_bio = BIO_new(BIO_s_mem());
+  PEM_write_bio_X509(pem_bio, requestor_cert);
+  BIO_get_mem_ptr(pem_bio, &pem_buf);
+  requestor_cert_pem = new_charbuf(pem_buf->length);
+  memcpy(requestor_cert_pem.chars, pem_buf->data, requestor_cert_pem.len);
+  BIO_free(pem_bio);
+  pem_buf = NULL;
+  pem_bio = NULL;
+
+  // create signature
+  signature = create_signature(requestor_privkey, &req_type, &key_id, &data, &requestor_cert_pem);
+  CU_ASSERT(signature.len > 0);
+
+  // check signature
+  ret = validate_signature(&req_type, &key_id, &data, &signature, &requestor_cert_pem);
+  CU_ASSERT(ret == 0);
+
+  X509_free(requestor_cert);
+  EVP_PKEY_free(requestor_privkey);
+}

--- a/test/src/util/request_signing_test_suite.c
+++ b/test/src/util/request_signing_test_suite.c
@@ -16,14 +16,34 @@
 
 #include <kmyth/formatting_tools.h>
 
+#include "common_table.h"
+#include "ec_key_cert_marshal.h"
+#include "pelz_loaders.h"
+
+#include "sgx_urts.h"
+#include "sgx_seal_unseal_impl.h"
+#include "pelz_enclave.h"
+#include ENCLAVE_HEADER_UNTRUSTED
 
 #define TEST_KEY_ID "file:/fake/path/to/key.txt"
 #define TEST_DATA "0123456789abcdef"
 
 
-int request_signing_test_suite_add_tests(CU_pSuite suite)
+int request_signing_suite_add_tests(CU_pSuite suite)
 {
+  if (NULL == CU_add_test(suite, "Test Signature Creation and Validation (Simplified)", test_create_validate_signature_simple))
+  {
+    return (1);
+  }
   if (NULL == CU_add_test(suite, "Test Signature Creation and Validation", test_create_validate_signature))
+  {
+    return (1);
+  }
+  if (NULL == CU_add_test(suite, "Test Cert Chain Validation", test_verify_cert_chain))
+  {
+    return (1);
+  }
+  if (NULL == CU_add_test(suite, "Test Cert Chain Validation in Enclave", test_verify_cert_chain_enclave))
   {
     return (1);
   }
@@ -33,8 +53,8 @@ int request_signing_test_suite_add_tests(CU_pSuite suite)
 /* Read remote certificate (X509) and private key from PEM files. */
 void load_test_key_pair(X509 **requestor_cert, EVP_PKEY **requestor_privkey)
 {
-  BIO *cert_bio = BIO_new_file("test/data/node_pub.pem", "r");
-  BIO *key_bio = BIO_new_file("test/data/node_priv.pem", "r");
+  BIO *cert_bio = BIO_new_file("test/data/worker_pub.pem", "r");
+  BIO *key_bio = BIO_new_file("test/data/worker_priv.pem", "r");
 
   *requestor_cert = PEM_read_bio_X509(cert_bio, NULL, 0, NULL);
   BIO_free(cert_bio);
@@ -43,13 +63,16 @@ void load_test_key_pair(X509 **requestor_cert, EVP_PKEY **requestor_privkey)
   BIO_free(key_bio);
 }
 
-void test_create_validate_signature(void)
+void test_create_validate_signature_simple(void)
 {
   int ret;
   X509 *requestor_cert;
   EVP_PKEY *requestor_privkey;
+  EVP_PKEY *requestor_pubkey;
   RequestType req_type = REQ_ENC;
-  charbuf key_id, data, requestor_cert_der, requestor_cert_encoded, signature;
+  charbuf key_id, data, requestor_cert_encoded, signature, serial;
+  unsigned char *der_buf = NULL;
+  int der_len = -1;
 
   // initialize request data
   key_id = new_charbuf(strlen(TEST_KEY_ID));
@@ -62,34 +85,159 @@ void test_create_validate_signature(void)
   load_test_key_pair(&requestor_cert, &requestor_privkey);
 
   // convert x509 to der format
-  requestor_cert_der = new_charbuf(0);
-  requestor_cert_der.len = i2d_X509(requestor_cert, &requestor_cert_der.chars);
-  if (requestor_cert_der.len == 0)
-  {
-    pelz_log(LOG_ERR, "i2d_X509 failed");
-  }
+  marshal_ec_x509_to_der(&requestor_cert, &der_buf, &der_len);
 
   // encode certificate
-  ret = encodeBase64Data(requestor_cert_der.chars, requestor_cert_der.len,
+  ret = encodeBase64Data(der_buf, der_len,
                          &requestor_cert_encoded.chars, &requestor_cert_encoded.len);
-  if (ret != 0)
-  {
-    pelz_log(LOG_ERR, "encodeBase64Data failed");
-  }
+  CU_ASSERT(ret == 0);
 
   // create signature
   signature = create_signature(requestor_privkey, &req_type, &key_id, &data, &requestor_cert_encoded);
   CU_ASSERT(signature.len > 0);
 
-  // check signature
-  ret = validate_signature(&req_type, &key_id, &data, &signature, &requestor_cert_encoded);
+  // Extract the public key from requestor_cert
+  requestor_pubkey = X509_get_pubkey(requestor_cert);
+
+  // Check the signature
+  serial = serialize_request_data(&req_type, &key_id, &data, &requestor_cert_encoded);
+  ret = verify_buffer(requestor_pubkey, serial.chars, serial.len, signature.chars, signature.len);
   CU_ASSERT(ret == 0);
 
+  free(der_buf);
   free_charbuf(&key_id);
   free_charbuf(&data);
-  free_charbuf(&requestor_cert_der);
   free_charbuf(&requestor_cert_encoded);
   free_charbuf(&signature);
+
+  X509_free(requestor_cert);
+  EVP_PKEY_free(requestor_privkey);
+}
+
+void test_create_validate_signature(void)
+{
+  int ret;
+  X509 *requestor_cert;
+  EVP_PKEY *requestor_privkey;
+  uint64_t handle;
+  TableResponseStatus status;
+  RequestType req_type = REQ_ENC;
+  charbuf key_id, data, requestor_cert_encoded, signature, signature_encoded;
+  unsigned char *der_buf = NULL;
+  int der_len = -1;
+
+  // initialize request data
+  key_id = new_charbuf(strlen(TEST_KEY_ID));
+  memcpy(key_id.chars, TEST_KEY_ID, key_id.len);
+
+  data = new_charbuf(strlen(TEST_DATA));
+  memcpy(key_id.chars, TEST_DATA, key_id.len);
+
+  // load key pair from file
+  load_test_key_pair(&requestor_cert, &requestor_privkey);
+
+  // load CA key to enclave
+  ret = pelz_load_file_to_enclave((char *) "test/data/test-ca.der.nkl", &handle);
+  CU_ASSERT(ret == 0);
+  add_cert_to_table(eid, &status, CA_TABLE, handle);
+  CU_ASSERT(status == OK);
+
+  // convert x509 to der format
+  marshal_ec_x509_to_der(&requestor_cert, &der_buf, &der_len);
+
+  // encode certificate
+  ret = encodeBase64Data(der_buf, der_len,
+                         &requestor_cert_encoded.chars, &requestor_cert_encoded.len);
+  CU_ASSERT(ret == 0);
+
+  // create signature
+  signature = create_signature(requestor_privkey, &req_type, &key_id, &data, &requestor_cert_encoded);
+  CU_ASSERT(signature.len > 0);
+
+  // encode sigature
+  ret = encodeBase64Data(signature.chars, signature.len,
+                         &signature_encoded.chars, &signature_encoded.len);
+  CU_ASSERT(ret == 0);
+
+  // check signature
+  ret = validate_signature(&req_type, &key_id, &data, &signature_encoded, &requestor_cert_encoded);
+  CU_ASSERT(ret == 0);
+
+  free(der_buf);
+  free_charbuf(&key_id);
+  free_charbuf(&data);
+  free_charbuf(&requestor_cert_encoded);
+  free_charbuf(&signature);
+
+  X509_free(requestor_cert);
+  EVP_PKEY_free(requestor_privkey);
+}
+
+void test_verify_cert_chain(void)
+{
+  X509 *requestor_cert;
+  X509 *ca_cert;
+  EVP_PKEY *requestor_privkey;
+
+  // load client key pair from file
+  load_test_key_pair(&requestor_cert, &requestor_privkey);
+
+  // load CA cert from file
+  BIO *cert_bio = BIO_new_file("test/data/test-ca.pem", "r");
+  ca_cert = PEM_read_bio_X509(cert_bio, NULL, 0, NULL);
+  BIO_free(cert_bio);
+
+  // Create cert store
+  X509_STORE *store = X509_STORE_new();
+
+  // Put ca certs in the store
+  X509_STORE_add_cert(store, ca_cert);
+
+  // Create store context
+  X509_STORE_CTX *store_ctx = X509_STORE_CTX_new();
+
+  X509_STORE_CTX_init(store_ctx, store, requestor_cert, NULL);
+
+  int success = X509_verify_cert(store_ctx);
+
+  X509_STORE_CTX_free(store_ctx);
+  X509_STORE_free(store);
+
+  X509_free(ca_cert);
+  X509_free(requestor_cert);
+  EVP_PKEY_free(requestor_privkey);
+
+  CU_ASSERT(success == 1);
+}
+
+void test_verify_cert_chain_enclave(void)
+{
+  int ret;
+  TableResponseStatus status;
+  X509 *requestor_cert;
+  EVP_PKEY *requestor_privkey;
+  uint64_t handle;
+  unsigned char *der_buf = NULL;
+  int der_len = -1;
+  charbuf der_cert = new_charbuf(0);
+
+  // load CA key to enclave
+  ret = pelz_load_file_to_enclave((char *) "test/data/test-ca.der.nkl", &handle);
+  CU_ASSERT(ret == 0);
+  add_cert_to_table(eid, &status, CA_TABLE, handle);
+  CU_ASSERT(status == OK);
+
+  // load key pair from file
+  load_test_key_pair(&requestor_cert, &requestor_privkey);
+
+  // convert x509 to der format
+  marshal_ec_x509_to_der(&requestor_cert, &der_buf, &der_len);
+  der_cert.chars = der_buf;
+  der_cert.len = der_len;
+
+  // Check cert chain
+  verify_cert(eid, &status, der_cert);
+  CU_ASSERT(status == OK);
 
   X509_free(requestor_cert);
   EVP_PKEY_free(requestor_privkey);


### PR DESCRIPTION
Signed requests are disabled in this PR.
The feature is still incomplete because we plan to move the signature/cert validation into the enclave and also encrypt sensitive data in signed requests and responses.
This PR just merges in the current code so that the development branches won't diverge too much.

There are working unit tests for signature/cert validation, but the tests for processing real signed JSON requests are incomplete.