### PR TITLE
Properly clean up all test key files.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -615,11 +615,11 @@ test: all test-all
 	@openssl x509 -in test/data/node_pub.pem -inform pem -out test/data/node_pub.der -outform der
 	@openssl x509 -in test/data/proxy_pub.pem -inform pem -out test/data/proxy_pub.der -outform der
 	@openssl pkey -in test/data/node_priv.pem -inform pem -out test/data/node_priv.der -outform der
-	@openssl x509 -in test/data/test-ca.pem -inform pem -out test/data/test-ca.der -outform der
+	@openssl x509 -in test/data/ca_pub.pem -inform pem -out test/data/ca_pub.der -outform der
 	@./bin/pelz seal test/data/node_pub.der -o test/data/node_pub.der.nkl
 	@./bin/pelz seal test/data/proxy_pub.der -o test/data/proxy_pub.der.nkl
 	@./bin/pelz seal test/data/node_priv.der -o test/data/node_priv.der.nkl
-	@./bin/pelz seal test/data/test-ca.der -o test/data/test-ca.der.nkl
+	@./bin/pelz seal test/data/ca_pub.der -o test/data/ca_pub.der.nkl
 	@echo "GEN => Test Key/Cert Files"
 	@cd kmyth/sgx && make demo-pre demo/bin/ecdh-server --eval="Demo_App_C_Flags += -DDEMO_LOG_LEVEL=LOG_WARNING"
 	@./kmyth/sgx/demo/bin/ecdh-server -r test/data/proxy_priv.pem -u test/data/node_pub.pem -p 7000 -m 1 2> /dev/null &
@@ -628,6 +628,8 @@ test: all test-all
 	@rm -f test/data/*.pem
 	@rm -f test/data/*.der
 	@rm -f test/data/*.nkl
+	@rm -f test/data/*.csr
+	@rm -f test/data/*.srl
 
 .PHONY: install-test-vectors
 

--- a/test/data/gen_test_keys_certs.bash
+++ b/test/data/gen_test_keys_certs.bash
@@ -7,9 +7,9 @@ openssl ecparam -name secp384r1 -genkey -noout -out proxy_priv.pem
 openssl req -new -x509 -key proxy_priv.pem -subj "/CN=localhost" -out proxy_pub.pem -days 365
 
 # Generate CA key+cert
-openssl req -new -x509 -nodes -subj "/CN=PelzTest-CA" -keyout test-ca.key -out test-ca.pem -days 365
+openssl req -new -x509 -nodes -subj "/CN=PelzTest-CA" -keyout ca_priv.pem -out ca_pub.pem -days 365
 
 # Generate key+csr+cert for remote client, signed by the CA
 openssl ecparam -name secp384r1 -genkey -noout -out worker_priv.pem
 openssl req -new -sha512 -key worker_priv.pem -subj "/CN=TestWorker" -out worker_pub.csr
-openssl x509 -req -sha256 -in worker_pub.csr -out worker_pub.pem -CAcreateserial -CAkey test-ca.key -CA test-ca.pem -days 365
+openssl x509 -req -sha256 -in worker_pub.csr -out worker_pub.pem -CAcreateserial -CAkey ca_priv.pem -CA ca_pub.pem -days 365

--- a/test/src/util/request_signing_test_suite.c
+++ b/test/src/util/request_signing_test_suite.c
@@ -143,7 +143,7 @@ void test_create_validate_signature(void)
   // load CA key to enclave
   table_destroy(eid, &status, CA_TABLE);
   CU_ASSERT(status == OK);
-  ret = pelz_load_file_to_enclave((char *) "test/data/test-ca.der.nkl", &handle);
+  ret = pelz_load_file_to_enclave((char *) "test/data/ca_pub.der.nkl", &handle);
   CU_ASSERT(ret == 0);
   add_cert_to_table(eid, &status, CA_TABLE, handle);
   CU_ASSERT(status == OK);
@@ -189,7 +189,7 @@ void test_verify_cert_chain(void)
   load_test_key_pair(&requestor_cert, &requestor_privkey);
 
   // load CA cert from file
-  BIO *cert_bio = BIO_new_file("test/data/test-ca.pem", "r");
+  BIO *cert_bio = BIO_new_file("test/data/ca_pub.pem", "r");
   ca_cert = PEM_read_bio_X509(cert_bio, NULL, 0, NULL);
   BIO_free(cert_bio);
 
@@ -244,7 +244,7 @@ void test_verify_cert_chain_enclave(void)
   CU_ASSERT(status != OK);
 
   // load CA key to enclave
-  ret = pelz_load_file_to_enclave((char *) "test/data/test-ca.der.nkl", &handle);
+  ret = pelz_load_file_to_enclave((char *) "test/data/ca_pub.der.nkl", &handle);
   CU_ASSERT(ret == 0);
   add_cert_to_table(eid, &status, CA_TABLE, handle);
   CU_ASSERT(status == OK);
@@ -268,7 +268,7 @@ void test_invalid_cert_chain_enclave(void)
   charbuf der_cert = new_charbuf(0);
 
   // load CA key to enclave
-  ret = pelz_load_file_to_enclave((char *) "test/data/test-ca.der.nkl", &handle);
+  ret = pelz_load_file_to_enclave((char *) "test/data/ca_pub.der.nkl", &handle);
   CU_ASSERT(ret == 0);
   add_cert_to_table(eid, &status, CA_TABLE, handle);
   CU_ASSERT(status == OK);


### PR DESCRIPTION
Also rename the test CA files for better consistency.