### PR TITLE
Fix a double free error in the pelz client.

### DIFF
--- a/src/pelz-service/main.c
+++ b/src/pelz-service/main.c
@@ -128,7 +128,12 @@ int main(int argc, char **argv)
   TableResponseStatus status;
   int ret;
 
-  sgx_create_enclave(ENCLAVE_PATH, SGX_DEBUG_FLAG, NULL, NULL, &eid, NULL);
+  sgx_status = sgx_create_enclave(ENCLAVE_PATH, SGX_DEBUG_FLAG, NULL, NULL, &eid, NULL);
+  if (sgx_status != SGX_SUCCESS) {
+    pelz_log(LOG_ERR, "Failed to load enclave %s, error code is 0x%x.\n", ENCLAVE_PATH, sgx_status);
+    return (1);
+  }
+
   sgx_status = kmyth_unsealed_data_table_initialize(eid, &ret);
   if (sgx_status != SGX_SUCCESS || ret != OK)
   {

--- a/src/util/file_seal_encrypt_decrypt.c
+++ b/src/util/file_seal_encrypt_decrypt.c
@@ -311,7 +311,7 @@ int read_validate(char *filename, uint8_t ** data, size_t *data_len)
      pelz_log(LOG_ERR, "seal input data file read error ... exiting");
      return 1;
   }
-  pelz_log(LOG_DEBUG, "read in %d bytes of data to be wrapped", data_len);
+  pelz_log(LOG_DEBUG, "read in %zu bytes of data to be wrapped", *data_len);
 
   // validate non-empty plaintext buffer specified
   if (data_len == 0 || data == NULL)

--- a/src/util/file_seal_encrypt_decrypt.c
+++ b/src/util/file_seal_encrypt_decrypt.c
@@ -111,7 +111,12 @@ int file_encrypt(char *filename, char **outpath, size_t outpath_size)
   RequestResponseStatus status;
   sgx_status_t sgx_status;
 
-  sgx_create_enclave(ENCLAVE_PATH, SGX_DEBUG_FLAG, NULL, NULL, &eid, NULL);
+  sgx_status = sgx_create_enclave(ENCLAVE_PATH, SGX_DEBUG_FLAG, NULL, NULL, &eid, NULL);
+  if (sgx_status != SGX_SUCCESS) {
+    pelz_log(LOG_ERR, "Failed to load enclave %s, error code is 0x%x.\n", ENCLAVE_PATH, sgx_status);
+    return 1;
+  }
+
   sgx_status = file_encrypt_in_enclave(eid, &status, plain_data, cipher_name, &cipher_data, &key, &iv, &tag);
   if (sgx_status != SGX_SUCCESS || status != REQUEST_OK)
   {
@@ -228,7 +233,12 @@ int file_decrypt(char *filename, char **outpath, size_t outpath_size)
   RequestResponseStatus status;
   sgx_status_t sgx_status;
 
-  sgx_create_enclave(ENCLAVE_PATH, SGX_DEBUG_FLAG, NULL, NULL, &eid, NULL);
+  sgx_status = sgx_create_enclave(ENCLAVE_PATH, SGX_DEBUG_FLAG, NULL, NULL, &eid, NULL);
+  if (sgx_status != SGX_SUCCESS) {
+    pelz_log(LOG_ERR, "Failed to load enclave %s, error code is 0x%x.\n", ENCLAVE_PATH, sgx_status);
+    return 1;
+  }
+
   sgx_status = file_decrypt_in_enclave(eid, &status, cipher_name, cipher_data, key, iv, tag, &plain_data);
   if (sgx_status != SGX_SUCCESS || status != REQUEST_OK)
   {
@@ -279,7 +289,11 @@ int seal_ski(uint8_t * data, size_t data_len, uint8_t ** data_out, size_t * data
 int seal_nkl(uint8_t * data, size_t data_len, uint8_t ** data_out, size_t *data_out_len)
 {
   pelz_log(LOG_DEBUG, "Seal_nkl function");        
-  sgx_create_enclave(ENCLAVE_PATH, SGX_DEBUG_FLAG, NULL, NULL, &eid, NULL);
+  sgx_status_t sgx_status = sgx_create_enclave(ENCLAVE_PATH, SGX_DEBUG_FLAG, NULL, NULL, &eid, NULL);
+  if (sgx_status != SGX_SUCCESS) {
+    pelz_log(LOG_ERR, "Failed to load enclave %s, error code is 0x%x.\n", ENCLAVE_PATH, sgx_status);
+    return 1;
+  }
 
   uint16_t key_policy = SGX_KEYPOLICY_MRENCLAVE;
   sgx_attributes_t attribute_mask;

--- a/src/util/file_seal_encrypt_decrypt.c
+++ b/src/util/file_seal_encrypt_decrypt.c
@@ -109,10 +109,11 @@ int file_encrypt(char *filename, char **outpath, size_t outpath_size)
   charbuf iv;
   charbuf tag;
   RequestResponseStatus status;
+  sgx_status_t sgx_status;
 
   sgx_create_enclave(ENCLAVE_PATH, SGX_DEBUG_FLAG, NULL, NULL, &eid, NULL);
-  file_encrypt_in_enclave(eid, &status, plain_data, cipher_name, &cipher_data, &key, &iv, &tag);
-  if (status != REQUEST_OK)
+  sgx_status = file_encrypt_in_enclave(eid, &status, plain_data, cipher_name, &cipher_data, &key, &iv, &tag);
+  if (sgx_status != SGX_SUCCESS || status != REQUEST_OK)
   {
     free_charbuf(&plain_data);
     sgx_destroy_enclave(eid);
@@ -225,10 +226,11 @@ int file_decrypt(char *filename, char **outpath, size_t outpath_size)
 
   charbuf plain_data;
   RequestResponseStatus status;
-  
+  sgx_status_t sgx_status;
+
   sgx_create_enclave(ENCLAVE_PATH, SGX_DEBUG_FLAG, NULL, NULL, &eid, NULL);
-  file_decrypt_in_enclave(eid, &status, cipher_name, cipher_data, key, iv, tag, &plain_data);
-  if (status != REQUEST_OK)
+  sgx_status = file_decrypt_in_enclave(eid, &status, cipher_name, cipher_data, key, iv, tag, &plain_data);
+  if (sgx_status != SGX_SUCCESS || status != REQUEST_OK)
   {
     free_charbuf(&cipher_name);
     free_charbuf(&cipher_data);

--- a/src/util/file_seal_encrypt_decrypt.c
+++ b/src/util/file_seal_encrypt_decrypt.c
@@ -110,7 +110,6 @@ int file_encrypt(char *filename, char **outpath, size_t outpath_size)
   charbuf tag;
   RequestResponseStatus status;
 
-
   sgx_create_enclave(ENCLAVE_PATH, SGX_DEBUG_FLAG, NULL, NULL, &eid, NULL);
   file_encrypt_in_enclave(eid, &status, plain_data, cipher_name, &cipher_data, &key, &iv, &tag);
   if (status != REQUEST_OK)
@@ -343,6 +342,7 @@ int outpath_validate(char *filename, char **outpath, size_t outpath_size, bool t
 
 int outpath_create(char *filename, char **outpath, bool tpm)
 {
+  char *temp_outpath;
   const char *ext;
   const char *TPM_EXT = ".ski";
   const char *NKL_EXT = ".nkl";
@@ -361,26 +361,27 @@ int outpath_create(char *filename, char **outpath, bool tpm)
   // a extension in the directory that the application is being run from.
   char *original_fn = basename(filename);
 
-  *outpath = (char *) malloc((strlen(original_fn) + strlen(ext) + 1) * sizeof(char));
+  temp_outpath = (char *) malloc((strlen(original_fn) + strlen(ext) + 1) * sizeof(char));
 
   // Make sure resultant default file name does not have empty basename
-  if (*outpath == NULL)
+  if (temp_outpath == NULL)
   {
     pelz_log(LOG_ERR, "invalid default filename derived ... exiting");
-    free(*outpath);
+    free(temp_outpath);
     return 1;
   }
 
-  sprintf(*outpath, "%.*s%.*s", (int) strlen(original_fn), original_fn, (int) strlen(ext), ext);
+  sprintf(temp_outpath, "%.*s%.*s", (int) strlen(original_fn), original_fn, (int) strlen(ext), ext);
   // Make sure default filename we constructed doesn't already exist
   struct stat st = { 0 };
-  if (!stat(*outpath, &st))
+  if (!stat(temp_outpath, &st))
   {
-    pelz_log(LOG_ERR, "default output filename (%s) already exists ... exiting", *outpath);
-    free(*outpath);
+    pelz_log(LOG_ERR, "default output filename (%s) already exists ... exiting", temp_outpath);
+    free(temp_outpath);
     return 1;
   }
 
+  *outpath = temp_outpath;
   pelz_log(LOG_DEBUG, "output file not specified, default = %s", *outpath);
   return 0;
 }


### PR DESCRIPTION
The double free occurred during seal/encrypt/decrypt when the default output file already existed.

Also add some return value checks for sgx functions and fix an incorrect log message.