### PR TITLE
Enable MRSIGNER check in attestation demo.

### DIFF
--- a/attestation_demo/EnclaveInitiator/EnclaveInitiator.cpp
+++ b/attestation_demo/EnclaveInitiator/EnclaveInitiator.cpp
@@ -52,13 +52,6 @@ std::map<sgx_enclave_id_t, dh_session_t>g_src_session_info_map;
 
 dh_session_t g_session;
 
-// This is hardcoded responder enclave's MRSIGNER for demonstration purpose. The content aligns to responder enclave's signing key
-sgx_measurement_t g_responder_mrsigner = {
-	{
-		0x83, 0xd7, 0x19, 0xe7, 0x7d, 0xea, 0xca, 0x14, 0x70, 0xf6, 0xba, 0xf6, 0x2a, 0x4d, 0x77, 0x43,
-		0x03, 0xc8, 0x99, 0xdb, 0x69, 0x02, 0x0f, 0x9c, 0x70, 0xee, 0x1d, 0xfc, 0x08, 0xc7, 0xce, 0x9e
-	}
-};
 
 /* Function Description:
  *   This is ECALL routine to create ECDH session.
@@ -112,15 +105,14 @@ uint32_t test_close_session()
  *   2. peer enclave's PROD_ID is as expected
  *   3. peer enclave's attribute is reasonable: it's INITIALIZED'ed enclave; in non-debug build configuration, the enclave isn't loaded with enclave debug mode.
  **/
-extern "C" uint32_t verify_peer_enclave_trust(sgx_dh_session_enclave_identity_t* peer_enclave_identity)
+extern "C" uint32_t verify_peer_enclave_trust(sgx_dh_session_enclave_identity_t* peer_enclave_identity, sgx_measurement_t *self_mr_signer)
 {
     if (!peer_enclave_identity)
         return INVALID_PARAMETER_ERROR;
 
-    // TODO: possibly compare peer enclave's MRSIGNER to known value
-    // check peer enclave's MRSIGNER
-    // if (memcmp((uint8_t *)&peer_enclave_identity->mr_signer, (uint8_t*)&g_responder_mrsigner, sizeof(sgx_measurement_t)))
-    //     return ENCLAVE_TRUST_ERROR;
+    // Check that both enclaves have the same MRSIGNER value
+    if (memcmp((uint8_t *)&peer_enclave_identity->mr_signer, (uint8_t*)self_mr_signer, sizeof(sgx_measurement_t)))
+        return ENCLAVE_TRUST_ERROR;
 
     // check peer enclave's product ID and enclave attribute (should be INITIALIZED'ed)
     if (peer_enclave_identity->isv_prod_id != RESPONDER_PRODID || !(peer_enclave_identity->attributes.flags & SGX_FLAGS_INITTED))

--- a/attestation_demo/EnclaveInitiator/EnclaveMessageExchange.cpp
+++ b/attestation_demo/EnclaveInitiator/EnclaveMessageExchange.cpp
@@ -49,7 +49,7 @@ extern "C" {
 #endif
 
 uint32_t message_exchange_response_generator(char* decrypted_data, char** resp_buffer, size_t* resp_length);
-uint32_t verify_peer_enclave_trust(sgx_dh_session_enclave_identity_t* peer_enclave_identity);
+uint32_t verify_peer_enclave_trust(sgx_dh_session_enclave_identity_t* peer_enclave_identity, sgx_measurement_t *self_mr_signer);
 
 #ifdef __cplusplus
 }
@@ -137,8 +137,10 @@ ATTESTATION_STATUS create_session(dh_session_t *session_info)
         return status;
     }
 
+    sgx_measurement_t *self_mr_signer = &dh_msg2.report.body.mr_signer;
+
     // Verify the identity of the destination enclave
-    if(verify_peer_enclave_trust(&responder_identity) != SUCCESS)
+    if(verify_peer_enclave_trust(&responder_identity, self_mr_signer) != SUCCESS)
     {
         return INVALID_SESSION;
     }

--- a/attestation_demo/EnclaveInitiator/Makefile
+++ b/attestation_demo/EnclaveInitiator/Makefile
@@ -44,7 +44,7 @@ Crypto_Library_Name := sgx_tcrypto
 ENCLAVE_NAME := libenclave_initiator.so
 SIGNED_ENCLAVE_NAME := libenclave_initiator.signed.so
 
-SIGNING_KEY := EnclaveInitiator_private_test.pem
+SIGNING_KEY := ../../sgx/pelz_enclave_private.pem
 
 # Message for missing Enclave Signing Key - Fatal Build Error
 define err_no_enclave_signing_key


### PR DESCRIPTION
This requires both enclaves to be signed with the same key at build time.