### PR TITLE
Resolve "multiple definition" build error for global_pipe_reader_active

### DIFF
--- a/src/util/fifo_thread.c
+++ b/src/util/fifo_thread.c
@@ -142,12 +142,20 @@ void *fifo_thread_process(void *arg)
 
   if (mkfifo(PELZSERVICE, MODE) == 0)
   {
-    pelz_log(LOG_DEBUG, "Pipe created successfully");
+    pelz_log(LOG_DEBUG, "pelz named pipe (FIFO) created successfully");
   }
   else if (errno != EEXIST)
   {
     pelz_log(LOG_DEBUG, "Error: %s", strerror(errno));
   }
+
+  // global_pipe_reader_active: boolean indicating pipe monitored for commands
+  //   - monitoring is performed in do-while loop below
+  //   - checked in socket listener loops (inactive will cause their exit)
+  //   - EXIT command will break out of loop (stop monitoring of named pipe)
+  //   - failed REMOVE ALL KEYS or REMOVE ALL CERTS will break out of loop 
+  //   - this boolean is reset (set to false/inactive) on loop exit
+  global_pipe_reader_active = true;
 
   do
   {
@@ -216,8 +224,9 @@ void *fifo_thread_process(void *arg)
     }
   }
   while (true);
-  pelz_log(LOG_DEBUG, "Global pipe reader thread exit");
+  
   global_pipe_reader_active = false;
+
+  pelz_log(LOG_DEBUG, "Global pipe reader thread exit");
   pthread_exit(NULL);
 }
-

--- a/src/util/fifo_thread.c
+++ b/src/util/fifo_thread.c
@@ -12,6 +12,7 @@
 #include "parse_pipe_message.h"
 #include "pelz_socket.h"
 #include "fifo_thread.h"
+#include "pelz_service.h"
 
 #include "sgx_urts.h"
 #include "pelz_enclave.h"
@@ -19,8 +20,6 @@
 
 #define BUFSIZE 1024
 #define MODE 0600
-
-bool global_pipe_reader_active;
 
 int send_table_id_list(char *pipe_name, TableType table_type, const char *resp_msg)
 {

--- a/src/util/pelz_service.c
+++ b/src/util/pelz_service.c
@@ -16,7 +16,7 @@
 #include "unsecure_socket_thread.h"
 #include "secure_socket_thread.h"
 
-bool global_pipe_reader_active = true;
+bool global_pipe_reader_active = false;
 
 static void *unsecure_thread_wrapper(void *arg)
 {

--- a/src/util/secure_socket_thread.c
+++ b/src/util/secure_socket_thread.c
@@ -82,7 +82,10 @@ void *secure_socket_thread(void *arg)
     pelz_log(LOG_INFO, "Secure Socket Thread %d, %d", (int) stid[socket_id], socket_id);
   }
   while (socket_listen_id >= 0 && socket_id <= (max_requests + 1) && global_pipe_reader_active);
+  
+  pelz_log(LOG_DEBUG, "secure socket (%d) teardown", socket_listen_id);
   pelz_key_socket_teardown(&socket_listen_id);
+
   return NULL;
 }
 

--- a/src/util/unsecure_socket_thread.c
+++ b/src/util/unsecure_socket_thread.c
@@ -81,7 +81,10 @@ void *unsecure_socket_thread(void *arg)
     pelz_log(LOG_INFO, "Unsecure Socket Thread %d, %d", (int) ustid[socket_id], socket_id);
   }
   while (socket_listen_id >= 0 && socket_id <= (max_requests + 1) && global_pipe_reader_active);
+  
+  pelz_log(LOG_DEBUG, "unsecure socket (%d) teardown", socket_listen_id);
   pelz_key_socket_teardown(&socket_listen_id);
+
   return NULL;
 }
 


### PR DESCRIPTION
When building in an updated environment (Ubuntu 22, gcc 11.4.0, SGX SDK 2.22, ...), building pelz yielded a multiple definition link error for the boolean `global_pipe_reader_active`.

This was corrected by removing the declaration in 'src/util/fifo_thread.c' and instead including it from 'include/pelz_service.h', where it is defined as an external variable.

This change was also tested in a legacy environment (Ubuntu 18, gcc 7.5.0, SGX SDK 2.15.1, ...), where pelz was building without this change, and found to build OK (with the change) in that environment as well.